### PR TITLE
Add §11: Usage-driven improvement via OODA loop

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -214,95 +214,64 @@ Every subcommand should support `--help` with a concise, complete reference: ava
 
 ## 11. Usage-driven improvement
 
-AXI defaults are guesses until agents use them. Instrument every AXI tool to log how it is actually used, then build a summary command that turns those logs into actionable tuning decisions.
+The defaults across §1–10 are guesses until agents use the tool. Build in a feedback loop: instrument real usage, surface it through a tool-native summary, and let the data refine the design.
 
-### What to log
+### What to capture
 
-Append one JSONL record per invocation to a local cache file (e.g. `~/.cache/mytool/usage.jsonl`). Logging must never break the CLI — silently drop on I/O errors. Each record should capture these AXI-relevant signals:
+Each invocation carries evidence about whether the AXI principles are being met. Capture one stream of signal per principle, defined broadly enough to encompass every override, error, or transition that informs compliance:
 
-| Signal | What to record | Which AXI principle it tunes |
-|--------|---------------|------------------------------|
-| **Command** | Command name, timestamp | Overall usage patterns |
-| **Schema** | Default fields and any `--fields` override | §2 Minimal default schemas |
-| **List length** | Default limit, requested limit, rows returned, total available | §2 Default limits |
-| **Parameterized defaults** | Default vs actual value for any flag with a meaningful default (limits, ranges, scopes) | §2 Default limits |
-| **Content truncation** | Whether `--full` was passed, count of truncated fields | §3 Content truncation |
-| **Aggregates** | Which aggregate keys appeared in the output | §4 Pre-computed aggregates |
-| **Empty results** | Whether the command returned 0 results on a successful call | §5 Definitive empty states |
-| **Errors** | Error message, whether contextual hints were shown, exit code | §6 Structured errors, §9 Contextual disclosure |
-| **Parse errors** | The raw argv when the CLI framework rejects input | §9 Contextual disclosure (missing flags) |
-| **Hints shown** | Which help hints appeared in the output | §9 Contextual disclosure (are hints guiding agents to what they actually do next?) |
-| **Latency** | Duration in milliseconds from entry to response | §4 Aggregates (high latency makes follow-up prevention more valuable) |
+| § | Principle | Signal to capture |
+|---|-----------|-------------------|
+| — | Foundational metadata | Command identity, timestamp, tool version, working directory, and any session or correlation key needed to sequence invocations, scope transitions to a single agent session, and tell which release of the tool produced each record. Required underneath every per-principle signal below |
+| 1 | Token-efficient output | Output size per invocation (bytes or tokens), so cost per call stays visible even when the format is fixed |
+| 2 | Minimal default schemas | Agent overrides of any defaulted parameter — fields, limits, scopes, ranges — distinguishing overrides that took effect from overrides clipped by a downstream cap, plus whether the returned result filled the limit. |
+| 3 | Content truncation | Full-content requests and how often truncation actually fires — together distinguishing "default too aggressive" from "content rarely long enough to matter" |
+| 4 | Pre-computed aggregates | Aggregates emitted on each invocation alongside follow-up calls that only read information the prior call could have included — together showing whether existing aggregates are doing their job and where new ones would help. Per-call latency, which scales the cost of every avoidable round-trip |
+| 5 | Definitive empty states | Successful zero-result invocations and what the agent does next — quiet acceptance, blind retry, or retry with widened parameters |
+| 6 | Structured errors & exit codes | Errors and exit codes by category (including idempotent no-ops), and the agent's response — recovery via the suggested command, blind retry, or abandonment |
+| 7 | Ambient context via session hooks | Whether session-start context fired and whether early agent actions reference state it surfaced rather than re-deriving it |
+| 8 | Content first | Bare/no-argument invocations and whether they are immediately followed by exploratory help calls |
+| 9 | Contextual disclosure | Hints emitted on each invocation versus the command the agent runs next — surfacing unhinted transitions and unfollowed hints. Raw input on parse errors, which names flags or commands the agent expected to exist |
+| 10 | Consistent way to get help | Help invocations and their context — bare exploration, post-error recovery, or mid-workflow lookup |
 
-**Key design rules:**
-
-- **Record defaults alongside overrides.** Logging that rows were overridden to 15 is useless without knowing the default was 10. Future analysis needs both to judge whether the default should change.
-- **Only log non-default values.** If the agent didn't override a parameter, omit the override key entirely — don't write `null`. This keeps records compact and makes "count of overrides" a simple key-existence check.
-- **Log on both success and error paths.** Error records need the same command-specific context as success records, plus the error message and exit code.
-- **Capture full argv on parse errors.** When the CLI framework rejects input, save the raw arguments so the summary can identify flags agents expect but don't exist.
+Logging must be cheap and must never break the CLI. Record both success and error paths. Record defaults alongside overrides so the analysis can judge whether the default itself should change. Storage format and location are implementation choices.
 
 ### What to detect
 
-The usage summary should surface three agent failure modes that benchmarking shows are the primary drivers of wasted cost and turns:
+Identify failures to comply with AXI principles and expected behaviors, e.g.:
 
-**Discovery friction** — The agent tries a flag or command that doesn't exist, gets an error, then falls back to `--help` before finding the right invocation. Detect by looking for parse errors ("No such option", "Unknown command") optionally followed by a `--help` call. Each instance is a wasted turn pair. The fix is either to add the expected flag, alias the expected command name, or improve contextual disclosure so the agent finds the right command on the first try.
+- **Repetition** — the agent re-runs a command with the same or escalated parameters. The first response didn't give it what it needed: defaults too narrow (§2), empty states not definitive (§5), or errors without a recovery path (§6).
+- **Re-derivation** — a later call only reads information that was already within reach of an earlier one. Schemas too minimal (§2), or pre-computed aggregates missing (§4).
+- **Surface mismatch** — the agent invokes something the tool doesn't expose, or has to discover state the tool should already have surfaced. Naming or surface area doesn't match expectations (§6, §9), ambient context isn't reaching the agent or isn't being used (§7), the bare invocation isn't showing useful live data (§8), or help is being leaned on across turns where contextual hints should suffice (§10).
+- **Capability gap** — a recurring sequence of successful invocations that together approximate a workflow the tool doesn't directly support. The agent isn't misusing existing surface; the surface itself is incomplete, and a new command, parameter, or aggregation would collapse the sequence into a single call (§4).
+- **Disclosure mismatch** — A→B transitions where A never hints at B reveal missing guidance; hints A consistently emits that no agent follows are noise (§9).
+- **Output bloat** — output size grows without proportional gain in information value, eroding token efficiency (§1) and the schema and truncation discipline of §2 and §3.
 
-**Retry cascades** — The agent re-runs the same command within seconds, often with escalating parameters (wider limits, broader filters). Detect by looking for the same command invoked twice within 30 seconds. Each cascade means the first response didn't give the agent what it needed — typically an empty result with no guidance, or an error without a recovery hint. The fix is better defaults, better empty-state messages, or better error hints.
-
-**Verification follow-ups** — The agent makes an extra call to confirm something that a pre-computed aggregate should have told it. Detect by looking for a detail/view command immediately after a list command for the same entity. If the detail call only reads a field that could have been in the list output, that field is a candidate for the default schema or for an aggregate. The fix is to promote the field or add a derived summary.
-
-**Unhinted transitions** — The agent follows command A with command B, but A's output didn't include a hint suggesting B. Detect by extracting command-pair sequences from timestamped logs (A→B within the same session or within a short time window) and comparing against the hints A actually emitted. Frequent A→B transitions where B isn't hinted reveal missing contextual disclosure (§9). The fix is to add a hint to A's output suggesting B, carrying forward any relevant context (identifiers, CRS codes, IDs) so the agent doesn't have to re-derive them. Conversely, if A hints at C but agents never actually run C, that hint is noise — consider removing it.
+Add categories as new principles or new failure shapes emerge — but keep them framed as agent-observable dysfunction, not log-field recipes.
 
 ### What to summarize
 
-Build a `mytool usage` subcommand that reads the JSONL log and reports insights. The output itself should be TOON. Organize the analysis around the four outcome metrics that AXI benchmarking tracks — **success rate, cost, duration, turns** — since every insight should connect to at least one:
+Expose a tool-native summary (e.g. a `usage` subcommand) that turns the captured signals into recommendations tied back to AXI principles. Don't just report statistics — name the principle, the signal that triggered the recommendation, the supporting sample size, and the concrete change, e.g.:
 
-**Schema analysis** (reduces turns) — Count how often each extra field is requested via `--fields`. Fields requested 2+ times are candidates to promote into the default schema. Report both the field names and their counts.
-
-**List length analysis** (reduces turns) — How often was the default row/result limit overridden? What values were used? Did any calls hit the limit (returned == requested)? Hitting the limit suggests the default is too low.
-
-**Parameterized default analysis** (reduces turns, improves success) — For any flag with a meaningful default (scopes, ranges, caps), track the same override-vs-default pattern as list length. High override rates or high empty-result rates signal the default isn't covering common cases.
-
-**Content truncation analysis** (reduces cost) — What fraction of calls used `--full`? High rates (>30%) suggest default truncation is too aggressive. Also report how many calls had truncated content, to distinguish "nobody needed full" from "nothing was long enough to truncate."
-
-**Empty result analysis** (improves success) — What fraction of successful calls returned 0 results? High empty rates signal that defaults aren't covering common agent queries. Break down by command.
-
-**Discovery friction** (reduces turns, cost) — How many parse errors occurred? How many were followed by `--help` lookups? Report the specific missing flags/commands with counts.
-
-**Retry cascades** (reduces turns, duration) — How many rapid re-invocations of the same command? Report by command, with the escalation pattern (e.g. "limit 10 → 20 → 50" or "same args, 3 attempts").
-
-**Follow-up patterns** (reduces turns) — How often does a detail command immediately follow a list of the same entity? Which fields does the detail call read that the list didn't include?
-
-**Command sequence analysis** (improves §9 contextual disclosure) — Extract the most frequent command-pair transitions (A→B) from the log. For each frequent pair, check whether A's recorded hints included a suggestion for B. Report:
-- *Unhinted transitions*: frequent A→B pairs where A didn't hint at B — these are missing hints that should be added.
-- *Unused hints*: hints that A consistently shows but no subsequent command ever matches — these are noise that can be removed or replaced.
-- *Effective hints*: A hinted at B and the agent followed through — these validate the current disclosure and should be preserved.
-
-This tells you whether your contextual disclosure (§9) is guiding agents toward what they actually do next, or toward commands they never use.
-
-**Error analysis** (improves success) — Categorize errors (parse errors, not-found, API errors, timeouts). Track what fraction included contextual hints — errors without hints are disclosure gaps (§9).
-
-**Latency analysis** (reduces duration) — Report avg and p95 duration. High latency makes pre-computed aggregates (§4) more valuable, since each prevented follow-up call saves more wall-clock time.
-
-**Actionable recommendations** — Synthesize the above into concrete suggestions:
-- "Add 'status' to default schema (requested 4 times — would save ~2 follow-up calls/session)"
-- "Consider adding flag: `mytool list --offset` (attempted 3 times, all parse errors)"
-- "Widen default --limit (65% of calls returned 0 results)"
-- "Add hints to parse error output (8 errors had no recovery guidance)"
-- "Add hint to `mytool list` suggesting `mytool view <id>` (12 list→view transitions, none hinted)"
-- "Remove hint for `mytool export` from `mytool list` (shown 30 times, never followed)"
-
-Don't just report statistics — tell the developer what to change and why.
+- **Trim per-call output (§1)** — output size trending upward without a proportional gain in information value.
+- **Promote a frequently-overridden field into the default schema (§2)** — recurring schema overrides for the same field across sessions.
+- **Widen a default limit, scope, or range (§2)** — calls regularly hit the cap or return zero results.
+- **Recalibrate default truncation (§3)** — high rate of full-content requests, or truncation rarely fires.
+- **Add a pre-computed aggregate (§4)** — re-derivation: follow-up calls regularly read information the prior call could have included inline.
+- **Strengthen empty-result output (§5)** — agents re-run the same query after zero results rather than treating it as definitive.
+- **Attach a recovery hint to an error class (§6, §9)** — recurring error without a contextual suggestion, followed by blind retries or abandonment.
+- **Move state into ambient session context (§7)** — early-session probes for state a session-start hook could have surfaced.
+- **Strengthen the bare-invocation view (§8)** — bare calls frequently followed by exploratory help calls.
+- **Add or remove a contextual hint (§9)** — frequent A→B transitions where A doesn't suggest B; or hints A emits that no agent ever follows.
+- **Reduce reliance on help text (§10)** — repeated help calls mid-workflow suggest contextual disclosure isn't carrying enough information.
 
 ### The improvement cycle
 
-The usage log and summary command create an OODA loop (Observe → Orient → Decide → Act):
+The instrumentation and summary form an OODA loop (Observe → Orient → Decide → Act):
 
-1. **Observe** — Every invocation appends a JSONL record. The log accumulates naturally during normal agent sessions with no manual effort.
-2. **Orient** — `mytool usage` reads the log and interprets it through AXI principles and the failure modes (discovery friction, retry cascades, verification follow-ups, unhinted transitions). This is the analysis: override rates, empty-result rates, error categories, retry counts, command sequences.
-3. **Decide** — The summary synthesizes observations into actionable recommendations: which fields to promote, which flags to add, which defaults to widen, which errors need hints. The developer reviews these against domain knowledge — a high empty-result rate might be expected (late-night queries) rather than a signal to change defaults.
-4. **Act** — Implement the changes. `mytool usage --clear` resets the log so the next cycle measures the impact of the changes, not the old baseline.
+1. **Observe** — invocations are recorded continuously, with no manual effort during normal agent sessions.
+2. **Orient** — the summary interprets the data through AXI principles and the failure modes above. Compare overrides against the current default set rather than the logged one, and use the tool version on each record so older behavior still informs analysis in context.
+3. **Decide** — each observation connects back to a specific principle and a concrete change. Validate proposals against the live tool surface. Treat the result as proposals — domain knowledge may justify a high override rate or empty-result rate.
+4. **Act** — apply the changes, then return to the loop, checking whether the targeted dysfunction signal dropped.
 
-Ship with best-guess defaults (§1–10 guide the initial choices), then start the loop. The principles tell you what to optimize for; the OODA cycle tells you whether you got it right. Cycle quickly — don't wait for a formal review cadence. The log is always accumulating, and `mytool usage` is always available.
-
-AXI benchmarking ([axi.md](https://axi.md/)) defines the outcome metrics to orient around: task success rate, cost per task, wall-clock duration, and tool-call turns. The usage summary connects each insight to these metrics so you can prioritize the changes that matter most.
+Ship with best-guess defaults (§1–10 guide the initial choices), then start the loop. The principles tell you what to optimize for; the OODA cycle tells you whether you got it right.

--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -211,3 +211,98 @@ description: Manage project tasks in the current workspace
 ```
 
 Every subcommand should support `--help` with a concise, complete reference: available flags with defaults, required arguments, and 2-3 usage examples. Keep it focused on the requested subcommand — don't dump the entire CLI's manual.
+
+## 11. Usage-driven improvement
+
+AXI defaults are guesses until agents use them. Instrument every AXI tool to log how it is actually used, then build a summary command that turns those logs into actionable tuning decisions.
+
+### What to log
+
+Append one JSONL record per invocation to a local cache file (e.g. `~/.cache/mytool/usage.jsonl`). Logging must never break the CLI — silently drop on I/O errors. Each record should capture these AXI-relevant signals:
+
+| Signal | What to record | Which AXI principle it tunes |
+|--------|---------------|------------------------------|
+| **Command** | Command name, timestamp | Overall usage patterns |
+| **Schema** | Default fields and any `--fields` override | §2 Minimal default schemas |
+| **List length** | Default limit, requested limit, rows returned, total available | §2 Default limits |
+| **Parameterized defaults** | Default vs actual value for any flag with a meaningful default (limits, ranges, scopes) | §2 Default limits |
+| **Content truncation** | Whether `--full` was passed, count of truncated fields | §3 Content truncation |
+| **Aggregates** | Which aggregate keys appeared in the output | §4 Pre-computed aggregates |
+| **Empty results** | Whether the command returned 0 results on a successful call | §5 Definitive empty states |
+| **Errors** | Error message, whether contextual hints were shown, exit code | §6 Structured errors, §9 Contextual disclosure |
+| **Parse errors** | The raw argv when the CLI framework rejects input | §9 Contextual disclosure (missing flags) |
+| **Hints shown** | Which help hints appeared in the output | §9 Contextual disclosure (are hints guiding agents to what they actually do next?) |
+| **Latency** | Duration in milliseconds from entry to response | §4 Aggregates (high latency makes follow-up prevention more valuable) |
+
+**Key design rules:**
+
+- **Record defaults alongside overrides.** Logging that rows were overridden to 15 is useless without knowing the default was 10. Future analysis needs both to judge whether the default should change.
+- **Only log non-default values.** If the agent didn't override a parameter, omit the override key entirely — don't write `null`. This keeps records compact and makes "count of overrides" a simple key-existence check.
+- **Log on both success and error paths.** Error records need the same command-specific context as success records, plus the error message and exit code.
+- **Capture full argv on parse errors.** When the CLI framework rejects input, save the raw arguments so the summary can identify flags agents expect but don't exist.
+
+### What to detect
+
+The usage summary should surface three agent failure modes that benchmarking shows are the primary drivers of wasted cost and turns:
+
+**Discovery friction** — The agent tries a flag or command that doesn't exist, gets an error, then falls back to `--help` before finding the right invocation. Detect by looking for parse errors ("No such option", "Unknown command") optionally followed by a `--help` call. Each instance is a wasted turn pair. The fix is either to add the expected flag, alias the expected command name, or improve contextual disclosure so the agent finds the right command on the first try.
+
+**Retry cascades** — The agent re-runs the same command within seconds, often with escalating parameters (wider limits, broader filters). Detect by looking for the same command invoked twice within 30 seconds. Each cascade means the first response didn't give the agent what it needed — typically an empty result with no guidance, or an error without a recovery hint. The fix is better defaults, better empty-state messages, or better error hints.
+
+**Verification follow-ups** — The agent makes an extra call to confirm something that a pre-computed aggregate should have told it. Detect by looking for a detail/view command immediately after a list command for the same entity. If the detail call only reads a field that could have been in the list output, that field is a candidate for the default schema or for an aggregate. The fix is to promote the field or add a derived summary.
+
+**Unhinted transitions** — The agent follows command A with command B, but A's output didn't include a hint suggesting B. Detect by extracting command-pair sequences from timestamped logs (A→B within the same session or within a short time window) and comparing against the hints A actually emitted. Frequent A→B transitions where B isn't hinted reveal missing contextual disclosure (§9). The fix is to add a hint to A's output suggesting B, carrying forward any relevant context (identifiers, CRS codes, IDs) so the agent doesn't have to re-derive them. Conversely, if A hints at C but agents never actually run C, that hint is noise — consider removing it.
+
+### What to summarize
+
+Build a `mytool usage` subcommand that reads the JSONL log and reports insights. The output itself should be TOON. Organize the analysis around the four outcome metrics that AXI benchmarking tracks — **success rate, cost, duration, turns** — since every insight should connect to at least one:
+
+**Schema analysis** (reduces turns) — Count how often each extra field is requested via `--fields`. Fields requested 2+ times are candidates to promote into the default schema. Report both the field names and their counts.
+
+**List length analysis** (reduces turns) — How often was the default row/result limit overridden? What values were used? Did any calls hit the limit (returned == requested)? Hitting the limit suggests the default is too low.
+
+**Parameterized default analysis** (reduces turns, improves success) — For any flag with a meaningful default (scopes, ranges, caps), track the same override-vs-default pattern as list length. High override rates or high empty-result rates signal the default isn't covering common cases.
+
+**Content truncation analysis** (reduces cost) — What fraction of calls used `--full`? High rates (>30%) suggest default truncation is too aggressive. Also report how many calls had truncated content, to distinguish "nobody needed full" from "nothing was long enough to truncate."
+
+**Empty result analysis** (improves success) — What fraction of successful calls returned 0 results? High empty rates signal that defaults aren't covering common agent queries. Break down by command.
+
+**Discovery friction** (reduces turns, cost) — How many parse errors occurred? How many were followed by `--help` lookups? Report the specific missing flags/commands with counts.
+
+**Retry cascades** (reduces turns, duration) — How many rapid re-invocations of the same command? Report by command, with the escalation pattern (e.g. "limit 10 → 20 → 50" or "same args, 3 attempts").
+
+**Follow-up patterns** (reduces turns) — How often does a detail command immediately follow a list of the same entity? Which fields does the detail call read that the list didn't include?
+
+**Command sequence analysis** (improves §9 contextual disclosure) — Extract the most frequent command-pair transitions (A→B) from the log. For each frequent pair, check whether A's recorded hints included a suggestion for B. Report:
+- *Unhinted transitions*: frequent A→B pairs where A didn't hint at B — these are missing hints that should be added.
+- *Unused hints*: hints that A consistently shows but no subsequent command ever matches — these are noise that can be removed or replaced.
+- *Effective hints*: A hinted at B and the agent followed through — these validate the current disclosure and should be preserved.
+
+This tells you whether your contextual disclosure (§9) is guiding agents toward what they actually do next, or toward commands they never use.
+
+**Error analysis** (improves success) — Categorize errors (parse errors, not-found, API errors, timeouts). Track what fraction included contextual hints — errors without hints are disclosure gaps (§9).
+
+**Latency analysis** (reduces duration) — Report avg and p95 duration. High latency makes pre-computed aggregates (§4) more valuable, since each prevented follow-up call saves more wall-clock time.
+
+**Actionable recommendations** — Synthesize the above into concrete suggestions:
+- "Add 'status' to default schema (requested 4 times — would save ~2 follow-up calls/session)"
+- "Consider adding flag: `mytool list --offset` (attempted 3 times, all parse errors)"
+- "Widen default --limit (65% of calls returned 0 results)"
+- "Add hints to parse error output (8 errors had no recovery guidance)"
+- "Add hint to `mytool list` suggesting `mytool view <id>` (12 list→view transitions, none hinted)"
+- "Remove hint for `mytool export` from `mytool list` (shown 30 times, never followed)"
+
+Don't just report statistics — tell the developer what to change and why.
+
+### The improvement cycle
+
+The usage log and summary command create an OODA loop (Observe → Orient → Decide → Act):
+
+1. **Observe** — Every invocation appends a JSONL record. The log accumulates naturally during normal agent sessions with no manual effort.
+2. **Orient** — `mytool usage` reads the log and interprets it through AXI principles and the failure modes (discovery friction, retry cascades, verification follow-ups, unhinted transitions). This is the analysis: override rates, empty-result rates, error categories, retry counts, command sequences.
+3. **Decide** — The summary synthesizes observations into actionable recommendations: which fields to promote, which flags to add, which defaults to widen, which errors need hints. The developer reviews these against domain knowledge — a high empty-result rate might be expected (late-night queries) rather than a signal to change defaults.
+4. **Act** — Implement the changes. `mytool usage --clear` resets the log so the next cycle measures the impact of the changes, not the old baseline.
+
+Ship with best-guess defaults (§1–10 guide the initial choices), then start the loop. The principles tell you what to optimize for; the OODA cycle tells you whether you got it right. Cycle quickly — don't wait for a formal review cadence. The log is always accumulating, and `mytool usage` is always available.
+
+AXI benchmarking ([axi.md](https://axi.md/)) defines the outcome metrics to orient around: task success rate, cost per task, wall-clock duration, and tool-call turns. The usage summary connects each insight to these metrics so you can prioritize the changes that matter most.


### PR DESCRIPTION
## Motivation

AXI §1–10 tell you *what* to optimize for, but not how to know whether you got it right. Every AXI tool ships with best-guess defaults — 3-4 default fields, a row limit, a truncation threshold — and those guesses stay frozen unless someone manually reviews agent behavior.

This PR proposes a new principle for discussion: instrument AXI tools to observe how agents actually use them, then feed that data back into tuning decisions.

## What this adds

**§11: Usage-driven improvement** — a new section covering:

1. **What to log** — a JSONL record per invocation capturing AXI-relevant signals: schema overrides, list-length overrides, parameterized default overrides, truncation usage, aggregates produced, errors with/without hints, parse errors with full argv, and latency.

2. **What to detect** — four agent failure modes, three identified by the [AXI benchmarks](https://axi.md/) as primary drivers of wasted cost and turns, plus a disclosure-quality signal:
   - *Discovery friction* — agent tries a nonexistent flag, falls back to `--help` (wasted turn pair)
   - *Retry cascades* — same command repeated within seconds with escalating parameters
   - *Verification follow-ups* — detail call after a list to read a field the default schema omitted
   - *Unhinted transitions* — agent frequently follows command A with command B, but A's output never suggested B (missing contextual disclosure)

3. **What to summarize** — a `mytool usage` subcommand that analyzes the log and reports insights organized around the four outcome metrics from AXI benchmarking (success rate, cost, duration, turns). Each analysis is annotated with which metrics it improves. Includes command sequence analysis that compares frequent A→B transitions against A's actual hints to identify missing, unused, and effective contextual disclosure.

4. **The improvement cycle** — framed as an OODA loop (Observe → Orient → Decide → Act) where logging is Observe, the summary command is Orient, recommendations are Decide, and implementing changes is Act.

## Rationale

This came from building an AXI tool interfacing with the UK rail Live Departure Boards web service and running this cycle in practice. Concrete examples of what usage data revealed:

- `rsid` was requested via `--fields` override in 2/3 of departure board calls → promoted to default schema (saves a follow-up turn every time the agent wants to drill into a service)
- `--offset` was attempted twice on the journey command and rejected as "No such option" → flag was added (eliminated a discovery-friction turn pair)
- 12/16 journey calls returned 0 results → identified as late-night queries (domain knowledge said *don't* widen the default, contradicting what a naive heuristic would suggest — illustrating why Orient and Decide must be separate steps)
- All 5 parse errors had zero contextual hints → added `--help` hint to error output

The OODA framing adds value beyond a numbered checklist because it separates Orient (mechanical analysis) from Decide (developer judgment). The log might show 75% empty results, but only the developer knows whether that's a default-parameter problem or an expected domain pattern.

## Open questions

- **Log format standardization**: should AXI prescribe a specific JSONL schema, or just the signal categories? A standard schema would let generic analysis tools work across AXI tools, but risks being too rigid for tools with different parameter shapes.

- **Privacy and retention**: the current guidance says "local cache file, clear with `--clear`". Should there be stronger guidance on retention limits, sensitive data in argv (e.g. API keys passed as flags), or opt-out mechanisms?

- **Cross-session analysis**: the current design treats each `mytool usage` run as a point-in-time snapshot. Would it be valuable to track *trends* across OODA cycles (e.g. "empty rate dropped from 46% to 12% after widening --window")? This would require not clearing the log, or maintaining a separate metrics history.

- **Automated recommendations vs. developer judgment**: the section recommends that the usage command output actionable suggestions ("Add 'status' to default schema"). How prescriptive should these be? There's a tension between making it easy to act on (concrete suggestions) and respecting that the developer may have domain reasons to reject them (as in the late-night journey example).

- **Scope**: is this the right level of detail for the skill prompt, or should the skill contain just the principles and link to a longer reference document for implementation guidance?
