### PR TITLE
fix(axi-sdk-js): install portable session hook commands

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -153,7 +153,7 @@ help[2]:
 
 - **Default app targets**: by default, support Claude Code and Codex. Do not hard-code a single agent integration when the tool can reasonably support both
 - **Self-installing**: register hooks at global/user level on first run — no manual setup required
-- **Absolute paths**: hook commands must use the full absolute path of the current executable (via `os.Executable()` or equivalent), not a bare command name. This ensures hooks work regardless of the agent's `$PATH` at runtime
+- **Portable commands**: hook commands should use a PATH-verified binary name when it resolves to the current executable, and fall back to the full absolute path otherwise. This keeps global installs portable while ensuring hooks do not accidentally run a different binary
 - **Path repair**: on every invocation, check existing hooks and update the executable path if it has changed (e.g., after reinstall or relocation). This turns self-install into self-heal
 - **Idempotent**: repeated installs with the same path are silent no-ops
 - **Directory-scoped**: show only state relevant to the current working directory

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -67,6 +67,12 @@ Most AXI authors should not need these directly.
 | `installSessionStartHooks()`             | Install or repair Claude Code and Codex session hooks directly |
 | `shouldInstallHooksForNodeAxiExecPath()` | Check whether an executable path should self-install hooks     |
 
+### Hook Command Portability
+
+`runAxiCli()` installs hooks automatically when it can infer the binary from the executable path. Hook commands use a plain binary name such as `gh-axi` only when `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
+
+For custom wrappers, pass `hooks: { binaryNames: ["my-axi"] }` to `runAxiCli()`. Direct callers can pass the same `binaryNames` option to `installSessionStartHooks()`.
+
 ## Development
 
 ```sh

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -65,6 +65,8 @@ Most AXI authors should not need these directly.
 | ---------------------------------------- | -------------------------------------------------------------- |
 | `AxiError`                               | Throw structured AXI errors from command handlers              |
 | `installSessionStartHooks()`             | Install or repair Claude Code and Codex session hooks directly |
+| `resolvePortableHookCommand()`           | Resolve a hook command to a safe binary name or absolute path  |
+| `PortableHookCommandContext`             | Context for resolving portable hook commands                   |
 | `shouldInstallHooksForNodeAxiExecPath()` | Check whether an executable path should self-install hooks     |
 
 ### Hook Command Portability

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -71,7 +71,7 @@ Most AXI authors should not need these directly.
 
 ### Hook Command Portability
 
-`runAxiCli()` installs hooks automatically when it can infer the binary from the executable path. Hook commands use a plain binary name such as `gh-axi` only when `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
+`runAxiCli()` installs hooks automatically when it can infer the binary from the executable path. Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
 
 For custom wrappers, pass `hooks: { binaryNames: ["my-axi"] }` to `runAxiCli()`. Direct callers can pass the same `binaryNames` option to `installSessionStartHooks()`.
 

--- a/packages/axi-sdk-js/package-lock.json
+++ b/packages/axi-sdk-js/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "axi-sdk-js",
       "version": "0.1.4",
+      "license": "MIT",
       "dependencies": {
         "@toon-format/toon": "^2.1.0"
       },

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -194,6 +194,7 @@ function installHooks(options: false | AxiCliHookOptions | undefined): void {
   installSessionStartHooks({
     marker,
     execPath: options.execPath ?? inferred.execPath,
+    binaryNames: options.binaryNames ?? inferred.binaryNames,
     homeDir: options.homeDir,
     timeoutSeconds: options.timeoutSeconds,
     shouldInstall:

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -1,6 +1,13 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join, resolve } from "node:path";
+import { basename, delimiter, dirname, join, resolve } from "node:path";
 
 export interface HookEntry {
   type?: string;
@@ -37,10 +44,17 @@ export interface NodeAxiExecPathPolicy {
 export interface InstallSessionStartHooksOptions {
   marker: string;
   execPath?: string;
+  binaryNames?: string[];
   timeoutSeconds?: number;
   homeDir?: string;
   shouldInstall?: (execPath: string) => boolean;
   onError?: (message: string) => void;
+}
+
+export interface PortableHookCommandContext {
+  pathEntries: string[];
+  pathExtensions: string[];
+  resolveRealPath: (absolutePath: string) => string | undefined;
 }
 
 function isManagedHook(hook: HookEntry | undefined, marker: string): boolean {
@@ -187,6 +201,64 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
   ];
 }
 
+export function resolvePortableHookCommand(
+  execPath: string,
+  binaryNames: string[],
+  marker: string,
+  context: PortableHookCommandContext,
+): string {
+  if (binaryNames.length === 0) {
+    return execPath;
+  }
+
+  const resolvedExec = context.resolveRealPath(execPath);
+  if (!resolvedExec) {
+    return execPath;
+  }
+
+  for (const name of binaryNames) {
+    if (!name.includes(marker)) {
+      continue;
+    }
+    for (const dir of context.pathEntries) {
+      if (!dir) continue;
+      for (const ext of context.pathExtensions) {
+        const candidate = join(dir, `${name}${ext}`);
+        const resolvedCandidate = context.resolveRealPath(candidate);
+        if (resolvedCandidate && resolvedCandidate === resolvedExec) {
+          return name;
+        }
+      }
+    }
+  }
+
+  return execPath;
+}
+
+function buildDefaultPortableCommandContext(): PortableHookCommandContext {
+  const rawPath = process.env.PATH ?? process.env.Path ?? "";
+  const pathEntries = rawPath.split(delimiter).filter(Boolean);
+  const pathExtensions =
+    process.platform === "win32"
+      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+      : [""];
+  return {
+    pathEntries,
+    pathExtensions,
+    resolveRealPath: (absolutePath) => {
+      try {
+        const stat = statSync(absolutePath);
+        if (!stat.isFile()) {
+          return undefined;
+        }
+        return realpathSync(absolutePath);
+      } catch {
+        return undefined;
+      }
+    },
+  };
+}
+
 export function shouldInstallHooksForNodeAxiExecPath(
   execPath: string,
   policy: NodeAxiExecPathPolicy,
@@ -220,6 +292,13 @@ export function installSessionStartHooks(
     return;
   }
 
+  const command = resolvePortableHookCommand(
+    execPath,
+    options.binaryNames ?? [],
+    options.marker,
+    buildDefaultPortableCommandContext(),
+  );
+
   const home = options.homeDir ?? homedir();
   const jsonTargets = [
     join(home, ".claude", "settings.json"),
@@ -235,7 +314,7 @@ export function installSessionStartHooks(
         : {};
       const [updated, changed] = computeSessionStartHookUpdate(current, {
         marker: options.marker,
-        command: execPath,
+        command,
         timeoutSeconds: options.timeoutSeconds,
       });
 

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -292,6 +292,7 @@ describe("runAxiCli", () => {
       expect.objectContaining({
         marker: "gh-axi",
         execPath: "/Users/me/src/gh-axi/dist/bin/gh-axi.js",
+        binaryNames: ["gh-axi"],
       }),
     );
 

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -1,7 +1,19 @@
-import { describe, expect, it } from "vitest";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   computeCodexConfigUpdate,
   computeSessionStartHookUpdate,
+  installSessionStartHooks,
+  resolvePortableHookCommand,
   shouldInstallHooksForNodeAxiExecPath,
 } from "../src/hooks.js";
 
@@ -176,6 +188,111 @@ describe("computeCodexConfigUpdate", () => {
   });
 });
 
+describe("resolvePortableHookCommand", () => {
+  const makeContext = (mapping: Record<string, string>) => ({
+    pathEntries: ["/usr/local/bin", "/opt/homebrew/bin"],
+    pathExtensions: [""],
+    resolveRealPath: (p: string) => mapping[p],
+  });
+
+  it("returns the plain binary name when PATH resolves to the same file", () => {
+    const exec = "/opt/homebrew/lib/node_modules/gh-axi/dist/bin/gh-axi.js";
+    const context = makeContext({
+      [exec]: exec,
+      "/opt/homebrew/bin/gh-axi": exec,
+    });
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe("gh-axi");
+  });
+
+  it("returns the absolute exec path when the binary is not on PATH", () => {
+    const exec = "/opt/homebrew/lib/node_modules/gh-axi/dist/bin/gh-axi.js";
+    const context = makeContext({ [exec]: exec });
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe(exec);
+  });
+
+  it("returns the absolute exec path when PATH resolves to a different file", () => {
+    const exec = "/Users/me/src/gh-axi/dist/bin/gh-axi.js";
+    const context = makeContext({
+      [exec]: exec,
+      "/usr/local/bin/gh-axi": "/other/install/gh-axi.js",
+    });
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe(exec);
+  });
+
+  it("skips a binary name that doesn't contain the marker", () => {
+    const exec = "/real/my-binary.js";
+    const context = makeContext({
+      [exec]: exec,
+      "/usr/local/bin/my-binary": exec,
+    });
+
+    expect(
+      resolvePortableHookCommand(exec, ["my-binary"], "custom-marker", context),
+    ).toBe(exec);
+  });
+
+  it("tries multiple binary names and returns the first match", () => {
+    const exec = "/real/gh-axi.js";
+    const context = makeContext({
+      [exec]: exec,
+      "/usr/local/bin/gh-axi": exec,
+    });
+
+    expect(
+      resolvePortableHookCommand(
+        exec,
+        ["nonexistent", "gh-axi"],
+        "gh-axi",
+        context,
+      ),
+    ).toBe("gh-axi");
+  });
+
+  it("tries multiple path extensions", () => {
+    const exec = "/real/gh-axi.js";
+    const context = {
+      pathEntries: ["/usr/local/bin"],
+      pathExtensions: ["", ".EXE", ".CMD"],
+      resolveRealPath: (p: string) =>
+        ({
+          [exec]: exec,
+          "/usr/local/bin/gh-axi.CMD": exec,
+        })[p],
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe("gh-axi");
+  });
+
+  it("returns exec path if execPath cannot be resolved", () => {
+    const context = makeContext({});
+    expect(
+      resolvePortableHookCommand(
+        "/missing/gh-axi.js",
+        ["gh-axi"],
+        "gh-axi",
+        context,
+      ),
+    ).toBe("/missing/gh-axi.js");
+  });
+
+  it("returns exec path when no binary names are provided", () => {
+    const exec = "/real/gh-axi.js";
+    const context = makeContext({ [exec]: exec });
+    expect(resolvePortableHookCommand(exec, [], "gh-axi", context)).toBe(exec);
+  });
+});
+
 describe("shouldInstallHooksForNodeAxiExecPath", () => {
   it("rejects development TypeScript entrypoints", () => {
     expect(
@@ -201,5 +318,108 @@ describe("shouldInstallHooksForNodeAxiExecPath", () => {
         },
       ),
     ).toBe(true);
+  });
+});
+
+describe("installSessionStartHooks (portable command)", () => {
+  let tmp: string;
+  let originalPath: string | undefined;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "axi-sdk-js-hooks-"));
+    originalPath = process.env.PATH;
+  });
+
+  afterEach(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("writes the plain binary name when a PATH symlink points at the exec file", () => {
+    const home = join(tmp, "home");
+    const pkgBin = join(tmp, "pkg", "dist", "bin");
+    const pathDir = join(tmp, "path-bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+    mkdirSync(pathDir, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+    symlinkSync(execFile, join(pathDir, "gh-axi"));
+
+    process.env.PATH = pathDir;
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      binaryNames: ["gh-axi"],
+      homeDir: home,
+    });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+  });
+
+  it("keeps the absolute exec path when the binary is not on PATH", () => {
+    const home = join(tmp, "home");
+    const pkgBin = join(tmp, "pkg", "dist", "bin");
+    const pathDir = join(tmp, "path-bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+    mkdirSync(pathDir, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+
+    process.env.PATH = pathDir;
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      binaryNames: ["gh-axi"],
+      homeDir: home,
+    });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
+  });
+
+  it("keeps the absolute exec path when PATH resolves to a different binary", () => {
+    const home = join(tmp, "home");
+    const pkgBin = join(tmp, "pkg", "dist", "bin");
+    const otherBin = join(tmp, "other", "dist", "bin");
+    const pathDir = join(tmp, "path-bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+    mkdirSync(otherBin, { recursive: true });
+    mkdirSync(pathDir, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    const otherFile = join(otherBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+    writeFileSync(otherFile, "// other\n", "utf-8");
+    symlinkSync(otherFile, join(pathDir, "gh-axi"));
+
+    process.env.PATH = pathDir;
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      binaryNames: ["gh-axi"],
+      homeDir: home,
+    });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
   });
 });


### PR DESCRIPTION
## Summary
- Installs session hooks with portable commands by resolving verified binary names through PATH and falling back to the absolute executable path when needed.
- Exports the hook command portability helper and marker-aware context for SDK callers.
- Updates the SDK README and AXI skill guidance to document `binaryNames`, marker constraints, and absolute path fallback behavior.

## Risk Assessment

⚠️ Medium: The change is narrowly scoped, but the core behavior introduces a runtime PATH dependency for automatically executed hooks, which is both a reliability and security regression if left as-is.

## Testing

- Summary: <code>Exercised the targeted portable hook command tests, the CLI hook propagation tests, and the full `axi-sdk-js` Vitest suite; all passed after installing dependencies and building `dist/` for subprocess fixtures.</code>
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test -- hooks.test.ts'`
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test -- cli.test.ts'`
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test'`
- Outcome: ✅ passed across 1 run (3m58s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>⚠️ **Review** - 1 warning</summary>

**Round 1** - found 1 warning
- ⚠️ `packages/axi-sdk-js/src/hooks.ts:229` - Returning the bare binary name makes the installed session hook depend on whatever PATH the agent process has at hook runtime, which may differ from install time and can also resolve to a different executable. Since this code already found the matching PATH entry, write that resolved PATH candidate, preferably normalized to an absolute path, instead of `name` so the hook remains portable via the stable symlink without runtime PATH hijacking/failure.

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test -- hooks.test.ts'`
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test -- cli.test.ts'`
- `zsh -lc 'source ~/.nvm/nvm.sh && npm test'`

</details>

<details>
<summary>🔧 **Document** - 2 issues found → auto-fixed (3)</summary>

**Round 1** - found 2 warnings
- ⚠️ `packages/axi-sdk-js/README.md:58` - The README documents hook installation only at a high level, but the change adds a new public behavior: hook commands may be written as the plain binary name when `binaryNames` resolves through PATH to the same executable, with absolute path fallback otherwise. Update the SDK docs to explain this behavior and the `binaryNames` option for both `runAxiCli({ hooks })` and direct `installSessionStartHooks()` callers.
- ⚠️ `.agents/skills/axi/SKILL.md:156` - The AXI skill still says hook commands must use the full absolute path and not a bare command name. That is stale relative to this change, which deliberately allows a PATH-verified binary name for portable hooks. Update the rule to describe the safe binary-name case and the absolute-path fallback.

**Round 2** (auto-fix) - found 1 warning
- ⚠️ `packages/axi-sdk-js/README.md:64` - The branch adds `resolvePortableHookCommand()` as an exported function through `src/index.ts`&#39;s `export * from &#34;./hooks.js&#34;`, making it part of the package API, but the README&#39;s Advanced Exports table still lists only the older hook helpers. Update the README export reference to either document `resolvePortableHookCommand()` and its context type or clarify that it is not intended as public API and remove it from the package barrel.

**Round 3** (auto-fix) - found 1 warning
- ⚠️ `packages/axi-sdk-js/README.md:74` - The Hook Command Portability section says a `binaryNames` entry is used whenever it resolves through PATH to the same executable, but the new resolver also requires the binary name to contain the hook `marker` before it is considered. Update this section so custom wrapper and direct `installSessionStartHooks()` users know that mismatched `marker`/`binaryNames` combinations intentionally fall back to the absolute `execPath`.

**Round 4** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
