### PR TITLE
fix: write canonical Codex hooks config key

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -163,7 +163,7 @@ help[2]:
 **How to integrate with each app:**
 
 - **Claude Code**: use native hooks in `~/.claude/settings.json` or project `.claude/settings.json`. Prefer `SessionStart` to inject compact context via stdout
-- **Codex**: use native hooks in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`, and ensure `[features].codex_hooks = true` in `config.toml`. Prefer `SessionStart` for ambient context via stdout
+- **Codex**: use native hooks in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`, and ensure `[features].hooks = true` in `config.toml`. Prefer `SessionStart` for ambient context via stdout
 
 ## 8. Content first
 

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -139,7 +139,7 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
   const normalized = content.length === 0 ? "" : content;
 
   if (normalized.trim().length === 0) {
-    return [`[features]${newline}codex_hooks = true${newline}`, true];
+    return [`[features]${newline}hooks = true${newline}`, true];
   }
 
   const lines = normalized.split(/\r?\n/);
@@ -161,7 +161,7 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
 
       const sectionName = section[2].trim();
       if (inFeatures) {
-        updated.splice(index, 0, "codex_hooks = true");
+        updated.splice(index, 0, "hooks = true");
         return [updated.join(newline), true];
       }
 
@@ -174,7 +174,7 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
       continue;
     }
 
-    const flag = line.match(/^\s*codex_hooks\s*=\s*(true|false)\s*(?:#.*)?$/);
+    const flag = line.match(/^\s*hooks\s*=\s*(true|false)\s*(?:#.*)?$/);
     if (!flag) {
       continue;
     }
@@ -189,14 +189,14 @@ export function computeCodexConfigUpdate(content: string): [string, boolean] {
 
   if (sawFeatures) {
     const suffix = normalized.endsWith(newline) ? "" : newline;
-    return [`${normalized}${suffix}codex_hooks = true${newline}`, true];
+    return [`${normalized}${suffix}hooks = true${newline}`, true];
   }
 
   const separator = normalized.endsWith(newline)
     ? newline
     : `${newline}${newline}`;
   return [
-    `${normalized}${separator}[features]${newline}codex_hooks = true${newline}`,
+    `${normalized}${separator}[features]${newline}hooks = true${newline}`,
     true,
   ];
 }

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -159,32 +159,41 @@ describe("computeSessionStartHookUpdate", () => {
 describe("computeCodexConfigUpdate", () => {
   it("creates a features section for empty config", () => {
     expect(computeCodexConfigUpdate("")).toEqual([
-      "[features]\ncodex_hooks = true\n",
+      "[features]\nhooks = true\n",
       true,
     ]);
   });
 
-  it("adds codex_hooks inside an existing features section", () => {
+  it("adds hooks inside an existing features section", () => {
     const [updated, changed] = computeCodexConfigUpdate(
       "[features]\nother = true\n",
     );
 
     expect(changed).toBe(true);
-    expect(updated).toBe("[features]\nother = true\ncodex_hooks = true\n");
+    expect(updated).toBe("[features]\nother = true\nhooks = true\n");
   });
 
-  it("repairs codex_hooks when it is disabled", () => {
+  it("repairs hooks when it is disabled", () => {
     const [updated, changed] = computeCodexConfigUpdate(
-      "[features]\ncodex_hooks = false\n",
+      "[features]\nhooks = false\n",
     );
 
     expect(changed).toBe(true);
-    expect(updated).toBe("[features]\ncodex_hooks = true\n");
+    expect(updated).toBe("[features]\nhooks = true\n");
   });
 
-  it("is a no-op when codex_hooks is already enabled", () => {
-    const original = "[features]\ncodex_hooks = true\n";
+  it("is a no-op when hooks is already enabled", () => {
+    const original = "[features]\nhooks = true\n";
     expect(computeCodexConfigUpdate(original)).toEqual([original, false]);
+  });
+
+  it("does not treat legacy codex_hooks as sufficient", () => {
+    const [updated, changed] = computeCodexConfigUpdate(
+      "[features]\ncodex_hooks = true\n",
+    );
+
+    expect(changed).toBe(true);
+    expect(updated).toBe("[features]\ncodex_hooks = true\nhooks = true\n");
   });
 });
 


### PR DESCRIPTION
Codex made `[features].hooks` the canonical config key for enabling hooks in [openai/codex#20522](https://github.com/openai/codex/pull/20522), which shipped in version `0.129.0`. Starting in that version, configs that still use `[features].codex_hooks` emit a deprecation warning:

> `[features].codex_hooks` is deprecated. Use `[features].hooks` instead.

Each time AXI's hook runs, it writes the deprecated `[features].codex_hooks` feature key to `config.toml`, causing the warning to continually surface in the Codex CLI and Codex app, even after the user migrates to the updated key.

This PR updates AXI's Codex hook config writer to use `[features].hooks` instead of `[features].codex_hooks`. Existing `[features].codex_hooks` entries are left unchanged; this PR only ensures `[features].hooks = true` is present.

## Changes

- Target `[features].hooks` instead of `[features].codex_hooks` when enabling Codex hooks.
- Update AXI skill guidance to reference `[features].hooks`.

## Validation

- `npm test`
- `npm run build`
- `npm run lint`
- `npm run format:check`