### PR TITLE
fix(axi-sdk-js): make session hook setup explicit

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -134,7 +134,7 @@ Register your tool into the agent's session lifecycle so every conversation star
 
 **Pattern:**
 
-1. On first invocation, self-install a session hook or plugin into the agent's configuration (idempotently)
+1. Provide an explicit setup command that installs or repairs a session hook or plugin after user intent is clear
 2. At session start, the integration runs your tool and provides a compact dashboard as context
 3. The agent receives this as initial context and can act immediately
 
@@ -152,9 +152,9 @@ help[2]:
 **Rules:**
 
 - **Default app targets**: by default, support Claude Code, Codex, and OpenCode. Do not hard-code a single agent integration when the tool can reasonably support multiple agents
-- **Self-installing**: register hooks or plugins at global/user level on first run — no manual setup required
+- **Explicit opt-in**: register hooks or plugins only from a user-invoked setup command, not from ordinary CLI commands
 - **Portable commands**: hook commands should use a PATH-verified binary name when it resolves to the current executable, and fall back to the full absolute path otherwise. This keeps global installs portable while ensuring hooks do not accidentally run a different binary
-- **Path repair**: on every invocation, check existing hooks and update the executable path if it has changed (e.g., after reinstall or relocation). This turns self-install into self-heal
+- **Path repair**: setup commands should check existing hooks and update the executable path if it has changed (e.g., after reinstall or relocation)
 - **Idempotent**: repeated installs with the same path are silent no-ops
 - **Directory-scoped**: show only state relevant to the current working directory
 - **Token-budget-aware**: this context loads on _every_ session — ruthlessly minimize it. Include just enough for the agent to orient and act; deep data belongs in explicit invocations

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ These principles define what makes a CLI tool "an AXI":
 | 4   | **Pre-computed aggregates**        | Include aggregated counts and statuses that eliminate round trips           |
 | 5   | **Definitive empty states**        | Explicit "0 results" rather than ambiguous empty output                     |
 | 6   | **Structured errors & exit codes** | Idempotent mutations, structured errors, no interactive prompts             |
-| 7   | **Ambient context**                | Self-install session integrations so agents see state before invoking       |
+| 7   | **Ambient context**                | Install opt-in session integrations so agents see state before invoking     |
 | 8   | **Content first**                  | Running with no arguments shows live data, not help text                    |
 | 9   | **Contextual disclosure**          | Include next-step suggestions after each output                             |
 | 10  | **Consistent way to get help**     | Concise per-subcommand reference when agents need it                        |

--- a/docs/index.html
+++ b/docs/index.html
@@ -449,7 +449,7 @@
               Idempotent mutations, structured errors, no interactive prompts
             </li>
             <li>
-              <strong>Ambient context</strong> &mdash; Self-install session
+              <strong>Ambient context</strong> &mdash; Install opt-in session
               integrations so agents see state before invoking
             </li>
             <li>
@@ -575,10 +575,11 @@ pull_request:
 
         <h4><span class="text-accent">7.</span> Ambient context</h4>
         <p>
-          Self-install into the agent&rsquo;s session hooks or plugin system so
-          that every conversation starts with relevant state already visible
-          &mdash; before the agent takes any action. The integration provides a
-          compact, directory-scoped dashboard as initial context.
+          Install into the agent&rsquo;s session hooks or plugin system from an
+          explicit setup command so that every conversation starts with relevant
+          state already visible &mdash; before the agent takes any action. The
+          integration provides a compact, directory-scoped dashboard as initial
+          context.
         </p>
 
         <h4><span class="text-accent">8.</span> Content first</h4>

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -77,9 +77,21 @@ Most AXI authors should not need these directly.
 Hook installation should be exposed through an explicit user-invoked setup command, for example `my-axi setup hooks`.
 
 ```ts
-import { installSessionStartHooks } from "axi-sdk-js";
+import { installSessionStartHooks, runAxiCli } from "axi-sdk-js";
 
-await installSessionStartHooks();
+await runAxiCli({
+  // ...other options
+  commands: {
+    setup: async (args) => {
+      if (args[0] !== "hooks") {
+        return { error: "Unknown setup command", help: "Run `my-axi setup hooks`" };
+      }
+
+      installSessionStartHooks();
+      return { setup: "hooks installed or already up to date" };
+    },
+  },
+});
 ```
 
 Calling `installSessionStartHooks()` without identity options infers the current CLI from `process.argv[1]`.

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -55,8 +55,8 @@ await runAxiCli({
 
 `axi-sdk-js` is a library package. In normal use, `runAxiCli()` should be the main entry point.
 
-| API           | Description                                                                                                                                                                                                           |
-| ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| API           | Description                                                                                                                                                                  |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, lazy context resolution, home header injection, TOON serialization, and standardized errors |
 
 ### Advanced Exports
@@ -84,7 +84,10 @@ await runAxiCli({
   commands: {
     setup: async (args) => {
       if (args[0] !== "hooks") {
-        return { error: "Unknown setup command", help: "Run `my-axi setup hooks`" };
+        return {
+          error: "Unknown setup command",
+          help: "Run `my-axi setup hooks`",
+        };
       }
 
       installSessionStartHooks();

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -11,9 +11,11 @@
 
 <h3 align="center">Ship AXIs without rewriting the boring parts.</h3>
 
-Every Node-based AXI ends up redoing the same work: top-level dispatch, structured errors, TOON output, and hook installation for a few agents.
+Every Node-based AXI ends up redoing the same work: top-level dispatch, structured errors, TOON output, and optional hook installation for a few agents.
 
-`axi-sdk-js` pulls those shared runtime pieces into one package. Your AXI can stay focused on business logic, work with plain JavaScript objects, and let the runtime handle official TOON serialization and agent session context plumbing.
+`axi-sdk-js` pulls those shared runtime pieces into one package.
+Your AXI can stay focused on business logic, work with plain JavaScript objects, and let the runtime handle official TOON serialization.
+If you want agent session context plumbing, wire `installSessionStartHooks()` into an explicit setup command.
 
 `runAxiCli()` assumes a command-first CLI shape: `<bin> <command> ...args ...flags`. Bare `--help` is still supported, but flags are not allowed before the top-level command.
 
@@ -55,7 +57,7 @@ await runAxiCli({
 
 | API           | Description                                                                                                                                                                                                           |
 | ------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, lazy context resolution, home header injection, TOON serialization, standardized errors, and automatic best-effort hook installation |
+| `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, lazy context resolution, home header injection, TOON serialization, and standardized errors |
 
 ### Advanced Exports
 
@@ -67,15 +69,37 @@ Most AXI authors should not need these directly.
 | `installSessionStartHooks()`             | Install or repair Claude Code hooks, Codex hooks, and OpenCode ambient context plugins directly |
 | `resolvePortableHookCommand()`           | Resolve a hook command to a safe binary name or absolute path                                   |
 | `PortableHookCommandContext`             | Context for resolving portable hook commands                                                    |
-| `shouldInstallHooksForNodeAxiExecPath()` | Check whether an executable path should self-install hooks                                      |
+| `shouldInstallHooksForNodeAxiExecPath()` | Check whether an executable path is safe for hook installation                                  |
+
+### Session Hook Setup
+
+`runAxiCli()` does not install hooks during normal CLI execution.
+Hook installation should be exposed through an explicit user-invoked setup command, for example `my-axi setup hooks`.
+
+```ts
+import { installSessionStartHooks } from "axi-sdk-js";
+
+await installSessionStartHooks();
+```
+
+Calling `installSessionStartHooks()` without identity options infers the current CLI from `process.argv[1]`.
+Packaged entrypoints such as `dist/bin/gh-axi.js` infer `marker: "gh-axi"`, `binaryNames: ["gh-axi"]`, and a safety policy that skips development TypeScript entrypoints.
+Pass explicit options when your setup command needs custom behavior:
+
+```ts
+await installSessionStartHooks({
+  marker: "my-axi",
+  binaryNames: ["my-axi"],
+});
+```
+
+Claude Code and Codex receive native `SessionStart` hooks, while OpenCode receives a managed plugin in `~/.config/opencode/plugins/` that injects the AXI home view as ambient model context.
 
 ### Hook Command Portability
 
-`runAxiCli()` installs hooks automatically when it can infer the binary from the executable path.
-Claude Code and Codex receive native `SessionStart` hooks, while OpenCode receives a managed plugin in `~/.config/opencode/plugins/` that injects the AXI home view as ambient model context.
 Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
 
-For custom wrappers, pass `hooks: { binaryNames: ["my-axi"] }` to `runAxiCli()`. Direct callers can pass the same `binaryNames` option to `installSessionStartHooks()`.
+For custom wrappers, pass `binaryNames: ["my-axi"]` to `installSessionStartHooks()`.
 
 ## Development
 

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -1,10 +1,6 @@
 import { basename } from "node:path";
 import { AxiError, exitCodeForError } from "./errors.js";
 import {
-  installSessionStartHooks,
-  shouldInstallHooksForNodeAxiExecPath,
-} from "./hooks.js";
-import {
   homeHeaderOutput,
   renderError,
   renderOutput,
@@ -19,17 +15,6 @@ export type AxiCliCommand<TContext> = (
   context: TContext | undefined,
 ) => MaybePromise<AxiRenderable>;
 
-export interface AxiCliHookOptions {
-  marker?: string;
-  execPath?: string;
-  homeDir?: string;
-  timeoutSeconds?: number;
-  binaryNames?: string[];
-  distEntrypoints?: string[];
-  shouldInstall?: (execPath: string) => boolean;
-  onError?: (message: string) => void;
-}
-
 export interface AxiResolveContextInput {
   command: string | undefined;
   args: string[];
@@ -42,7 +27,6 @@ export interface AxiCliOptions<TContext = undefined> {
   topLevelHelp: string;
   commands: Record<string, AxiCliCommand<TContext>>;
   home: AxiCliCommand<TContext>;
-  hooks?: false | AxiCliHookOptions;
   getCommandHelp?: (command: string) => string | null | undefined;
   initialize?: () => void;
   resolveContext?: (input: AxiResolveContextInput) => MaybePromise<TContext>;
@@ -78,7 +62,6 @@ function defaultUnknownCommand(command: string): string {
 export async function runAxiCli<TContext = undefined>(
   options: AxiCliOptions<TContext>,
 ): Promise<void> {
-  installHooks(options.hooks);
   options.initialize?.();
 
   const stdout = options.stdout ?? process.stdout;
@@ -173,90 +156,6 @@ function renderLeadingFlagError(flag: string): string {
 
 function isVersionFlag(flag: string): boolean {
   return flag === "-v" || flag === "-V" || flag === "--version";
-}
-
-function installHooks(options: false | AxiCliHookOptions | undefined): void {
-  if (options === false) {
-    return;
-  }
-
-  if (!options) {
-    options = {};
-  }
-
-  const inferred = inferHookOptions(options.execPath ?? process.argv[1]);
-  if (!inferred) {
-    return;
-  }
-
-  const marker = options.marker ?? inferred.marker;
-
-  installSessionStartHooks({
-    marker,
-    execPath: options.execPath ?? inferred.execPath,
-    binaryNames: options.binaryNames ?? inferred.binaryNames,
-    homeDir: options.homeDir,
-    timeoutSeconds: options.timeoutSeconds,
-    shouldInstall:
-      options.shouldInstall ??
-      buildHookInstallPolicy(marker, options, inferred),
-    onError: options.onError,
-  });
-}
-
-function buildHookInstallPolicy(
-  marker: string,
-  options: AxiCliHookOptions,
-  inferred: InferredHookOptions,
-): ((execPath: string) => boolean) | undefined {
-  const binaryNames = options.binaryNames ?? inferred.binaryNames;
-  const distEntrypoints = options.distEntrypoints ?? inferred.distEntrypoints;
-
-  return (execPath: string) =>
-    shouldInstallHooksForNodeAxiExecPath(execPath, {
-      marker,
-      binaryNames,
-      distEntrypoints,
-    });
-}
-
-interface InferredHookOptions {
-  execPath: string;
-  marker: string;
-  binaryNames: string[];
-  distEntrypoints: string[];
-}
-
-function inferHookOptions(
-  execPath: string | undefined,
-): InferredHookOptions | undefined {
-  if (!execPath) {
-    return undefined;
-  }
-
-  const normalized = execPath.replaceAll("\\", "/");
-  const match = normalized.match(/(?:^|\/)dist\/bin\/([^/]+)\.js$/);
-  if (match?.[1]) {
-    const marker = match[1];
-    return {
-      execPath,
-      marker,
-      binaryNames: [marker],
-      distEntrypoints: [`dist/bin/${marker}.js`],
-    };
-  }
-
-  const fileName = normalized.split("/").pop() ?? "";
-  if (!fileName || fileName.includes(".") || fileName === "node") {
-    return undefined;
-  }
-
-  return {
-    execPath,
-    marker: fileName,
-    binaryNames: [fileName],
-    distEntrypoints: [`dist/bin/${fileName}.js`],
-  };
 }
 
 function renderCommandOutput<TContext>(

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -42,9 +42,10 @@ export interface NodeAxiExecPathPolicy {
 }
 
 export interface InstallSessionStartHooksOptions {
-  marker: string;
+  marker?: string;
   execPath?: string;
   binaryNames?: string[];
+  distEntrypoints?: string[];
   timeoutSeconds?: number;
   homeDir?: string;
   shouldInstall?: (execPath: string) => boolean;
@@ -430,22 +431,92 @@ export function shouldInstallHooksForNodeAxiExecPath(
   );
 }
 
-export function installSessionStartHooks(
+interface InferredHookOptions {
+  execPath: string;
+  marker: string;
+  binaryNames: string[];
+  distEntrypoints: string[];
+}
+
+function inferHookOptions(
+  execPath: string | undefined,
+): InferredHookOptions | undefined {
+  if (!execPath) {
+    return undefined;
+  }
+
+  const normalized = execPath.replaceAll("\\", "/");
+  const match = normalized.match(/(?:^|\/)dist\/bin\/([^/]+)\.js$/);
+  if (match?.[1]) {
+    const marker = match[1];
+    return {
+      execPath,
+      marker,
+      binaryNames: [marker],
+      distEntrypoints: [`dist/bin/${marker}.js`],
+    };
+  }
+
+  const fileName = normalized.split("/").pop() ?? "";
+  if (!fileName || fileName.includes(".") || fileName === "node") {
+    return undefined;
+  }
+
+  return {
+    execPath,
+    marker: fileName,
+    binaryNames: [fileName],
+    distEntrypoints: [`dist/bin/${fileName}.js`],
+  };
+}
+
+function buildInferredHookInstallPolicy(
+  marker: string,
   options: InstallSessionStartHooksOptions,
+  inferred: InferredHookOptions,
+): (execPath: string) => boolean {
+  const binaryNames = options.binaryNames ?? inferred.binaryNames;
+  const distEntrypoints = options.distEntrypoints ?? inferred.distEntrypoints;
+
+  return (execPath: string) =>
+    shouldInstallHooksForNodeAxiExecPath(execPath, {
+      marker,
+      binaryNames,
+      distEntrypoints,
+    });
+}
+
+export function installSessionStartHooks(
+  options: InstallSessionStartHooksOptions = {},
 ): void {
-  const execPath = resolve(options.execPath ?? process.argv[1] ?? "");
+  const inferred = inferHookOptions(options.execPath ?? process.argv[1]);
+  const marker = options.marker ?? inferred?.marker;
+  if (!marker) {
+    return;
+  }
+
+  const execPath = resolve(
+    options.execPath ?? inferred?.execPath ?? process.argv[1] ?? "",
+  );
   if (!execPath) {
     return;
   }
 
-  if (options.shouldInstall && !options.shouldInstall(execPath)) {
+  const shouldInstall =
+    options.shouldInstall ??
+    (inferred
+      ? buildInferredHookInstallPolicy(marker, options, inferred)
+      : undefined);
+  if (shouldInstall && !shouldInstall(execPath)) {
     return;
   }
 
+  const binaryNames = options.binaryNames ?? inferred?.binaryNames ?? [];
+
   const command = resolvePortableHookCommand(
     execPath,
-    options.binaryNames ?? [],
-    options.marker,
+    binaryNames,
+    marker,
     buildDefaultPortableCommandContext(),
   );
 
@@ -458,7 +529,7 @@ export function installSessionStartHooks(
 
   installOpenCodeAmbientPlugin(
     home,
-    options.marker,
+    marker,
     command,
     options.timeoutSeconds ?? 10,
     options.onError,
@@ -471,7 +542,7 @@ export function installSessionStartHooks(
         ? (JSON.parse(readFileSync(target, "utf-8")) as HookSettings)
         : {};
       const [updated, changed] = computeSessionStartHookUpdate(current, {
-        marker: options.marker,
+        marker,
         command,
         timeoutSeconds: options.timeoutSeconds,
       });

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -502,11 +502,15 @@ export function installSessionStartHooks(
     return;
   }
 
+  const defaultPolicyOptions = inferred ?? {
+    execPath,
+    marker,
+    binaryNames: [marker],
+    distEntrypoints: [`dist/bin/${marker}.js`],
+  };
   const shouldInstall =
     options.shouldInstall ??
-    (inferred
-      ? buildInferredHookInstallPolicy(marker, options, inferred)
-      : undefined);
+    buildInferredHookInstallPolicy(marker, options, defaultPolicyOptions);
   if (shouldInstall && !shouldInstall(execPath)) {
     return;
   }

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -276,42 +276,12 @@ describe("runAxiCli", () => {
     expect(home).toHaveBeenCalledWith([], { repo: "owner/name" });
   });
 
-  it("installs hooks automatically from the executable path", async () => {
+  it("does not install hooks automatically from the executable path", async () => {
     process.argv = ["node", "/Users/me/src/gh-axi/dist/bin/gh-axi.js"];
 
     await runAxiCli({
       description: "Manage GitHub state",
       topLevelHelp: "top help",
-      home,
-      commands: { issue },
-      stdout,
-    });
-
-    expect(installSessionStartHooks).toHaveBeenCalledTimes(1);
-    expect(installSessionStartHooks).toHaveBeenCalledWith(
-      expect.objectContaining({
-        marker: "gh-axi",
-        execPath: "/Users/me/src/gh-axi/dist/bin/gh-axi.js",
-        binaryNames: ["gh-axi"],
-      }),
-    );
-
-    const options = installSessionStartHooks.mock.calls[0]?.[0];
-    expect(
-      options.shouldInstall("/Users/me/src/gh-axi/dist/bin/gh-axi.js"),
-    ).toBe(true);
-    expect(options.shouldInstall("/Users/me/src/gh-axi/bin/gh-axi.ts")).toBe(
-      false,
-    );
-  });
-
-  it("allows automatic hook installation to be disabled", async () => {
-    process.argv = ["node", "/Users/me/src/gh-axi/dist/bin/gh-axi.js"];
-
-    await runAxiCli({
-      description: "Manage GitHub state",
-      topLevelHelp: "top help",
-      hooks: false,
       home,
       commands: { issue },
       stdout,

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -386,6 +386,21 @@ describe("installSessionStartHooks (portable command)", () => {
     expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
   });
 
+  it("skips explicit marker hooks for development TypeScript entrypoints", () => {
+    const home = join(tmp, "home");
+    const execFile = join(tmp, "gh-axi", "bin", "gh-axi.ts");
+    mkdirSync(join(tmp, "gh-axi", "bin"), { recursive: true });
+    writeFileSync(execFile, "// stub\n", "utf-8");
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      homeDir: home,
+    });
+
+    expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
+  });
+
   it("writes the plain binary name when a PATH symlink points at the exec file", () => {
     const home = join(tmp, "home");
     const pkgBin = join(tmp, "pkg", "dist", "bin");

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -337,10 +337,12 @@ describe("shouldInstallHooksForNodeAxiExecPath", () => {
 describe("installSessionStartHooks (portable command)", () => {
   let tmp: string;
   let originalPath: string | undefined;
+  let originalArgv: string[];
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "axi-sdk-js-hooks-"));
     originalPath = process.env.PATH;
+    originalArgv = [...process.argv];
   });
 
   afterEach(() => {
@@ -349,7 +351,39 @@ describe("installSessionStartHooks (portable command)", () => {
     } else {
       process.env.PATH = originalPath;
     }
+    process.argv = originalArgv;
     rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("infers current CLI hook options when no identity options are provided", () => {
+    const home = join(tmp, "home");
+    const pkgBin = join(tmp, "pkg", "dist", "bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+    process.argv = ["node", execFile];
+
+    installSessionStartHooks({ homeDir: home });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
+    expect(settings.hooks.SessionStart[0].hooks[0].timeout).toBe(10);
+  });
+
+  it("skips inferred current CLI hooks for development TypeScript entrypoints", () => {
+    const home = join(tmp, "home");
+    const execFile = join(tmp, "gh-axi", "bin", "gh-axi.ts");
+    mkdirSync(join(tmp, "gh-axi", "bin"), { recursive: true });
+    writeFileSync(execFile, "// stub\n", "utf-8");
+    process.argv = ["node", execFile];
+
+    installSessionStartHooks({ homeDir: home });
+
+    expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
   });
 
   it("writes the plain binary name when a PATH symlink points at the exec file", () => {


### PR DESCRIPTION
## Intent

The developer wanted to address a GitHub issue about the JavaScript SDK silently auto-installing agent session hooks into user-wide Claude, Codex, and OpenCode configuration during normal CLI execution. They asked to investigate the issue, consider downstream SDK usage such as gh-axi, and propose then implement an opt-in model. They wanted normal CLI commands to be side-effect free, with hook installation moved to an explicit setup command, while preserving a simple installer API where installSessionStartHooks() can infer the current CLI defaults when called without options. They also expected tests and documentation to reflect the new behavior and downstream consumers to migrate away from implicit hooks.

## What Changed

- Removed automatic session hook installation from normal `runAxiCli` execution so ordinary CLI commands no longer write user-wide agent configuration.
- Moved hook installation behavior into the explicit `installSessionStartHooks()` API, with safeguards for development entrypoints and preserved default inference when invoked from setup flows.
- Updated SDK tests and documentation, the AXI skill, README, and website copy to describe opt-in hook setup instead of self-installing session integrations.

## Risk Assessment

✅ Low: The change is narrowly scoped to removing implicit hook setup and adding guarded explicit installation inference, with tests covering the main safety paths and no material risks found in the reviewed diff.

## Testing

<code>I ran the relevant axi-sdk-js automated tests, handled the unsupported inline `vite-node` runner by building the package, then exercised the compiled end-user path in an isolated home directory: normal `runAxiCli()` produced a home view without creating hook files, while explicit `installSessionStartHooks()` installed Claude, Codex, and OpenCode hook configuration successfully.</code>

<details>
<summary>Evidence: End-to-end CLI no-op vs explicit setup transcript</summary>

```text
{
"normalCommandOutput": "bin: /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/axi-e2e-qahxp0/pkg/dist/bin/gh-axi.js\ndescription: Manage GitHub state\nstatus: home view",
"normalCommandTouchedHookFiles": [],
"explicitSetup": {
"claudeCommand": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/axi-e2e-qahxp0/pkg/dist/bin/gh-axi.js",
"codexCommand": "/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/axi-e2e-qahxp0/pkg/dist/bin/gh-axi.js",
"codexConfig": "[features]\nhooks = true",
"opencodeManagedPlugin": true
}
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed</summary>

**Round 1** - found 1 warning
- ⚠️ `packages/axi-sdk-js/src/hooks.ts:505` - When callers pass an explicit marker but run the setup command from a development TypeScript entrypoint, inference returns undefined, so no default shouldInstall policy is applied and installSessionStartHooks will write user hooks pointing at the .ts file. That recreates the bad persistent hook state the old runAxiCli inference path avoided for development entrypoints.

**Round 2** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Test** - passed</summary>

**Round 1** - passed ✅
- `pnpm --dir packages/axi-sdk-js test -- --runInBand`
- <code>`pnpm --dir packages/axi-sdk-js exec vite-node -e ...` (attempted e2e runner; this vite-node version requires script files, so no product behavior was exercised)</code>
- `pnpm --dir packages/axi-sdk-js run build`
- <code>`node -e &#39;...&#39;` using `packages/axi-sdk-js/dist/index.js` to simulate normal CLI execution followed by explicit `installSessionStartHooks({ homeDir })`</code>

</details>

<details>
<summary>🔧 **Document** - 1 issue found → auto-fixed (2)</summary>

**Round 1** - found 1 warning
- ⚠️ `packages/axi-sdk-js/README.md:79` - The new behavior requires hook installation to happen only from an explicit user-invoked setup command, but the Session Hook Setup example shows a bare top-level `await installSessionStartHooks();` immediately after that guidance. Copied as-is, this can be placed at module startup and recreate the normal-command side effect the change is removing. Update the example to show `installSessionStartHooks()` inside a concrete `setup hooks` command handler wired through `runAxiCli()`, ideally with a short success/no-op output example.

**Round 2** (auto-fix) - found 2 warnings
- ⚠️ `README.md:77` - The top-level principle table still describes ambient context as &#34;Self-install session integrations&#34;, but the change explicitly removes automatic hook installation from normal CLI execution and updates the AXI skill to require explicit user-invoked setup. Update this summary to say integrations are opt-in/installed via an explicit setup command so the public project overview does not continue recommending the removed behavior.
- ⚠️ `docs/index.html:452` - The website copy for principle 7 still says &#34;Self-install session integrations&#34; in the principles list and &#34;Self-install into the agent&#39;s session hooks&#34; in the detailed Ambient context section. This is stale relative to the new explicit-hook-setup behavior and the updated skill guidance. Update both website occurrences to describe explicit opt-in setup/install/repair instead of self-installing during ordinary CLI use.

**Round 3** (auto-fix) - passed ✅

</details>

<details>
<summary>✅ **Lint** - passed</summary>

**Round 1** - passed ✅

</details>

<details>
<summary>✅ **Push** - passed</summary>

**Round 1** - passed ✅

</details>
