### PR TITLE
feat: recommend installable agent skills

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -166,6 +166,20 @@ help[2]:
 - **Codex**: use native hooks in `~/.codex/hooks.json` or `<repo>/.codex/hooks.json`, and ensure `[features].hooks = true` in `config.toml`. Prefer `SessionStart` for ambient context via stdout
 - **OpenCode**: use a managed plugin in `~/.config/opencode/plugins/`. Prefer ambient system-context injection for the home view rather than adding a custom tool
 
+**Also ship an installable skill (secondary recommendation):**
+
+The session hook is the primary integration, but it only helps agents whose harness supports hooks, and it loads on _every_ session. Offer an installable [Agent Skill](https://agentskills.io) as a secondary discovery path. It loads on demand when the agent recognizes a matching task, carries no per-session token cost, and works in any agent that supports the skill format. Recommend the hook first (ambient context plus live state) and the skill second (lower overhead, broader agent support) — they are complementary, and a user installs whichever fits, or both.
+
+```sh
+npx skills add <owner>/<repo> --skill <name>
+```
+
+- **Single source of truth**: generate `SKILL.md` from the same content your no-args home view prints, so the skill never drifts from the CLI's own guidance. Add a `--check` build step to CI that fails if the committed skill is stale
+- **Strip live state**: a skill is static, so omit dynamic data (open sessions, current items) that only the hook can show
+- **Non-interactive commands**: rewrite command examples to a form the agent can run without a global install (e.g. `npx -y mytool ...`), since a skill may be installed without the binary on PATH
+- **Trigger-shaped frontmatter**: include `name` and a `description` written as a trigger — terse and outcome-focused so the agent loads it on the right intent
+- **Document both paths**: in your README, present the hook and the skill as two ways to achieve the same thing, and make clear the user only needs one
+
 ## 8. Content first
 
 Running your CLI with no arguments should show the most relevant live content — not a usage manual.

--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -168,7 +168,10 @@ help[2]:
 
 **Also ship an installable skill (secondary recommendation):**
 
-The session hook is the primary integration, but it only helps agents whose harness supports hooks, and it loads on _every_ session. Offer an installable [Agent Skill](https://agentskills.io) as a secondary discovery path. It loads on demand when the agent recognizes a matching task, carries no per-session token cost, and works in any agent that supports the skill format. Recommend the hook first (ambient context plus live state) and the skill second (lower overhead, broader agent support) — they are complementary, and a user installs whichever fits, or both.
+The session hook is the primary integration, but it only helps agents whose harness supports hooks, and it loads on _every_ session.
+Offer an installable [Agent Skill](https://agentskills.io) as a secondary discovery path.
+It loads on demand when the agent recognizes a matching task, carries no per-session token cost, and works in any agent that supports the skill format.
+Recommend the hook first (ambient context plus live state) and the skill second (lower overhead, broader agent support) - they are complementary, and a user installs whichever fits, or both.
 
 ```sh
 npx skills add <owner>/<repo> --skill <name>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 AI agents interact with external services through two dominant paradigms today: **CLIs** which were originally built for humans, and structured tool protocols like **MCP**. Both impose significant overhead.
 
-AXI is a **new paradigm** — agent-native CLI tools built from **10 design principles** that treat token budget as a first-class constraint.
+AXI is a **new paradigm** - agent-native CLI tools built from **10 design principles** that treat token budget as a first-class constraint.
 
 ## Results
 
@@ -74,7 +74,7 @@ These principles define what makes a CLI tool "an AXI":
 | 4   | **Pre-computed aggregates**        | Include aggregated counts and statuses that eliminate round trips           |
 | 5   | **Definitive empty states**        | Explicit "0 results" rather than ambiguous empty output                     |
 | 6   | **Structured errors & exit codes** | Idempotent mutations, structured errors, no interactive prompts             |
-| 7   | **Ambient context**                | Install opt-in session integrations so agents see state before invoking     |
+| 7   | **Ambient context**                | Install opt-in session integrations first, then offer an on-demand skill    |
 | 8   | **Content first**                  | Running with no arguments shows live data, not help text                    |
 | 9   | **Contextual disclosure**          | Include next-step suggestions after each output                             |
 | 10  | **Consistent way to get help**     | Concise per-subcommand reference when agents need it                        |
@@ -87,7 +87,9 @@ Install the AXI skill to get the design guidelines and scaffolding for building 
 npx skills add kunchenguid/axi
 ```
 
-This installs the [AXI skill](.agents/skills/axi/SKILL.md) — a detailed guide with examples for each principle that your coding agent can reference while building.
+This installs the [AXI skill](.agents/skills/axi/SKILL.md) - a detailed guide with examples for each principle that your coding agent can reference while building.
+For your own AXI, expose an explicit setup command for session hooks as the primary integration, then ship an installable Agent Skill as a lower-overhead secondary path.
+Users only need one path, but hooks and skills complement each other when both are available.
 
 ## Development
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -579,7 +579,10 @@ pull_request:
           explicit setup command so that every conversation starts with relevant
           state already visible &mdash; before the agent takes any action. The
           integration provides a compact, directory-scoped dashboard as initial
-          context.
+          context. As a secondary recommendation, also ship an installable Agent
+          Skill (generated from the same home-view guidance) so agents that
+          support the skill format can load your guidance on demand, without the
+          per-session cost of a hook.
         </p>
 
         <h4><span class="text-accent">8.</span> Content first</h4>

--- a/docs/index.html
+++ b/docs/index.html
@@ -450,7 +450,7 @@
             </li>
             <li>
               <strong>Ambient context</strong> &mdash; Install opt-in session
-              integrations so agents see state before invoking
+              integrations first, then offer an on-demand skill
             </li>
             <li>
               <strong>Content first</strong> &mdash; Prefer showing actual data,


### PR DESCRIPTION
## Intent

The developer wanted the AXI skill in this repository to make installable agent skills a standard secondary recommendation for AXI CLIs, modeled on the pattern used in the lavish-axi repo. They wanted AXIs to continue recommending setup/session hooks as the primary path for ambient context, while also encouraging a generated, installable skill for on-demand use with lower per-session token cost. The transcript explicitly emphasized that this should be positioned as an additional recommendation, not a replacement for setup hooks.

## What Changed

- Added AXI skill guidance recommending installable Agent Skills as a secondary discovery path alongside primary session hooks.
- Documented implementation rules for generated skills, including shared source content, static-only guidance, non-interactive command examples, trigger-focused frontmatter, and README coverage.
- Updated the README and website principle summaries to present hooks first and on-demand skills as complementary integration paths.

## Risk Assessment

✅ Low: The branch only adds bounded documentation and skill guidance, with no executable code or behavior changes.

## Testing

I reviewed the changed files, ran the focused SDK regression tests, rendered the docs page locally, captured a browser screenshot of the end-user skill install card, extracted the rendered Principle 7 copy, and verified the skill/docs wording preserves setup/session hooks as primary while positioning installable skills as the secondary low-token-cost path; all final checks passed, with two intermediate evidence commands retried after command/setup issues that were not product failures.

- Evidence: Rendered docs page showing AXI skill install card (local file: <code>/var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTCMEP939YDJP2YCGCQZAQCC/docs-skill-install-card.png</code>)
<details>
<summary>Evidence: Rendered Principle 7 copy extracted from browser DOM</summary>

```text
Install into the agent’s session hooks or plugin system from an explicit setup command so that every conversation starts with relevant state already visible - before the agent takes any action. The integration provides a compact, directory-scoped dashboard as initial context. As a secondary recommendation, also ship an installable Agent Skill (generated from the same home-view guidance) so agents that support the skill format can load your guidance on demand, without the per-session cost of a hook.
```
</details>
<details>
<summary>Evidence: Intent wording checks for skill and docs</summary>

```text
PASS skill secondary heading
PASS skill primary wording
PASS skill low token cost wording
PASS docs ambient primary wording
PASS docs skill secondary wording
PASS docs install command
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-only 9c2d6e5594707ddfa80a8ff8b7426c02ea485d3f..616468b2c87e8073a202f880de6ea67ebc380a8a`
- `pnpm --dir packages/axi-sdk-js test`
- <code>`python3 -m http.server --directory docs 8766` plus `chrome-devtools-axi open http://127.0.0.1:8766/`</code>
- `chrome-devtools-axi screenshot /var/folders/5x/4nqprlbx0518k3ybcb1sz6gr0000gn/T/no-mistakes-evidence/01KTCMEP939YDJP2YCGCQZAQCC/docs-skill-install-card.png`
- `chrome-devtools-axi eval "() => Array.from(document.querySelectorAll('h4')).find((h) => h.textContent.includes('7. Ambient context')).nextElementSibling.textContent.trim()"`
- `node -e '...checks guidance wording with corrected regex...'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
