### PR TITLE
docs: add gws-axi, harvest-axi, specops, and gitsheets-axi to the catalog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -403,6 +403,20 @@
                     an AXI embedded in a skill, not a standalone npm executable.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a
+                      href="https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi"
+                      ><code>gitsheets-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Git-backed data</td>
+                  <td>
+                    Read and mutate git-backed record sheets over the shell -
+                    TOON output, idempotent commits.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -364,6 +364,45 @@
                     token-efficient output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/gws-axi"
+                      ><code>gws-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Google Workspace</td>
+                  <td>
+                    Gmail, Calendar, Docs, Drive, and Slides behind one command,
+                    with multi-account write-safety - drafts mail, never sends.
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/harvest-axi"
+                      ><code>harvest-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Time tracking</td>
+                  <td>
+                    Review, log, and edit Harvest time entries by period - for
+                    yourself, your team, a project, or a client.
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/specops"
+                      ><code>specops</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Spec-driven dev</td>
+                  <td>
+                    Spec-driven development for agents - and a demo of shipping
+                    an AXI embedded in a skill, not a standalone npm executable.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Adds four more Jarvus AXI tools to the **Community** catalog table, alongside the existing `slack-axi`:

| AXI | Domain | Description |
|---|---|---|
| [`gws-axi`](https://github.com/JarvusInnovations/gws-axi) | Google Workspace | Gmail, Calendar, Docs, Drive, and Slides behind one command, with multi-account write-safety — drafts mail, never sends. |
| [`harvest-axi`](https://github.com/JarvusInnovations/harvest-axi) | Time tracking | Review, log, and edit Harvest time entries by period — for yourself, your team, a project, or a client. |
| [`specops`](https://github.com/JarvusInnovations/specops) | Spec-driven dev | Spec-driven development for agents — and a demo of shipping an AXI embedded in a skill, not a standalone npm executable. |
| [`gitsheets-axi`](https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi) | Git-backed data | Read and mutate git-backed record sheets over the shell — TOON output, idempotent commits. |

Notes:
- `specops` is intentionally framed to highlight that it **distributes an AXI embedded within a Claude Code skill** rather than as a standalone npm executable — a distribution pattern worth surfacing in the catalog.
- `gitsheets-axi` ships as a **monorepo subpackage** (published `gitsheets-axi@1.3.x` on npm) of `JarvusInnovations/gitsheets` — another packaging variant alongside the standalone-repo and embedded-in-skill patterns. Link points at `packages/gitsheets-axi` on `main`.
- Descriptions were reviewed against each tool's latest release and matched to the catalog's existing form (verb-led where it fits, `" - "` spaced hyphen rather than em-dash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)