### PR TITLE
Add npm-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ AXIs built and maintained by the community:
 
 | AXI                                                                | Author             | Domain | What it does                                                                       |
 | ------------------------------------------------------------------ | ------------------ | ------ | ----------------------------------------------------------------------------------- |
+| [`npm-axi`](https://github.com/SSBrouhard/npm-axi)                 | SSBrouhard         | npm    | Search and inspect npm registry packages, versions, dependencies, README previews, and downloads with token-efficient output. |
 | [`slack-axi`](https://github.com/JarvusInnovations/slack-axi)      | Jarvus Innovations | Slack  | Read, search, sweep, and safely draft Slack messages with token-efficient output.  |
 
 Built an AXI? [Open a PR](https://github.com/kunchenguid/axi/pulls) to add it to this list.

--- a/docs/index.html
+++ b/docs/index.html
@@ -353,6 +353,20 @@
               <tbody>
                 <tr>
                   <td>
+                    <a href="https://github.com/SSBrouhard/npm-axi"
+                      ><code>npm-axi</code></a
+                    >
+                  </td>
+                  <td>SSBrouhard</td>
+                  <td>npm</td>
+                  <td>
+                    Search and inspect npm registry packages, versions,
+                    dependencies, README previews, and downloads with
+                    token-efficient output.
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     <a href="https://github.com/JarvusInnovations/slack-axi"
                       ><code>slack-axi</code></a
                     >


### PR DESCRIPTION
## Summary

Adds `npm-axi` to the AXI community catalog in both the README and static site catalog.

`npm-axi` is a read-only npm registry AXI for searching and inspecting packages, versions, dependencies, README previews, and downloads with token-efficient output.

## Validation

- `git diff --check`

This is a docs-only catalog update, so I did not run the benchmark or package test suites.