### PR TITLE
docs: add metabase-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ AXIs built and maintained by the community:
 | [`harvest-axi`](https://github.com/JarvusInnovations/harvest-axi)                                  | Jarvus Innovations | Time tracking    | Review, log, and edit Harvest time entries by period - for yourself, your team, a project, or a client.                       |
 | [`specops`](https://github.com/JarvusInnovations/specops)                                          | Jarvus Innovations | Spec-driven dev  | Spec-driven development for agents - and a demo of shipping an AXI embedded in a skill, not a standalone npm executable.      |
 | [`gitsheets-axi`](https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi) | Jarvus Innovations | Git-backed data  | Read and mutate git-backed record sheets over the shell - TOON output, idempotent commits.                                    |
+| [`metabase-axi`](https://github.com/JarvusInnovations/metabase-axi)                                | Jarvus Innovations | Analytics / BI   | Query, explore, and export from Metabase over the shell - SQL/MBQL, saved questions, schema introspection, full-data export.  |
 
 Built an AXI? Follow the [contributor workflow](CONTRIBUTING.md) to add it to this list.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -431,6 +431,20 @@
                     TOON output, idempotent commits.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/metabase-axi"
+                      ><code>metabase-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Analytics / BI</td>
+                  <td>
+                    Query, explore, and export from Metabase over the shell -
+                    SQL/MBQL, saved questions, schema introspection, full-data
+                    export.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## What changed

Adds a `metabase-axi` row to the Community AXI catalog in the two places it is maintained:

- `README.md` — the community catalog table
- `docs/index.html` — the matching table on the axi.md site

| Field | Value |
| --- | --- |
| AXI | [`metabase-axi`](https://github.com/JarvusInnovations/metabase-axi) |
| Author | Jarvus Innovations |
| Domain | Analytics / BI |
| What it does | Query, explore, and export from Metabase over the shell — SQL/MBQL, saved questions, schema introspection, full-data export. |

Appended as the last row after `gitsheets-axi` to match the existing chronological ordering; the README row is space-padded to the table's fixed column widths. Docs-only — no code or SDK changes.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Validated through `git push no-mistakes`: review, test, document, and lint all passed with no findings on the catalog change. This PR intentionally contains only the two catalog files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
