### PR TITLE
docs: add otter-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ AXIs built and maintained by the community:
 | [`harvest-axi`](https://github.com/JarvusInnovations/harvest-axi)                                  | Jarvus Innovations | Time tracking    | Review, log, and edit Harvest time entries by period - for yourself, your team, a project, or a client.                       |
 | [`specops`](https://github.com/JarvusInnovations/specops)                                          | Jarvus Innovations | Spec-driven dev  | Spec-driven development for agents - and a demo of shipping an AXI embedded in a skill, not a standalone npm executable.      |
 | [`gitsheets-axi`](https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi) | Jarvus Innovations | Git-backed data  | Read and mutate git-backed record sheets over the shell - TOON output, idempotent commits.                                    |
+| [`otter-axi`](https://github.com/JarvusInnovations/otter-axi)                                      | Jarvus Innovations | Meetings         | Find and pull Otter.ai meeting transcripts from the shell - wraps Otter.ai's hosted MCP server as a scriptable, headless CLI. |
 
 Built an AXI? Follow the [contributor workflow](CONTRIBUTING.md) to add it to this list.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -431,6 +431,20 @@
                     TOON output, idempotent commits.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/otter-axi"
+                      ><code>otter-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Meetings</td>
+                  <td>
+                    Find and pull Otter.ai meeting transcripts from the shell -
+                    wraps Otter.ai's hosted MCP server as a scriptable, headless
+                    CLI.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## What changed

Adds an `otter-axi` row to the Community AXI catalog in the two places it is maintained:

- `README.md` — the community catalog table
- `docs/index.html` — the matching table on the axi.md site

| Field | Value |
| --- | --- |
| AXI | [`otter-axi`](https://github.com/JarvusInnovations/otter-axi) |
| Author | Jarvus Innovations |
| Domain | Meetings |
| What it does | Find and pull Otter.ai meeting transcripts from the shell — wraps Otter.ai's hosted MCP server as a scriptable, headless CLI. |

Notable as an AXI that **wraps a public, hosted MCP server**: Otter's hosted MCP connector re-prompts for auth and can't be scripted, so otter-axi turns that same sanctioned MCP server into a non-interactive CLI (`search`/`fetch`) with token-efficient TOON output — a demonstration that the AXI ergonomics layer can front an MCP backend.

Appended as the last row after `gitsheets-axi`; the README row is space-padded to the table's fixed column widths. Docs-only — no code or SDK changes.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Validated through `git push no-mistakes`: review, test, document, and lint all passed with no findings. This PR contains only the two catalog files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
