### PR TITLE
docs: add metabase-axi and otter-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ AXIs built and maintained by the community:
 | [`harvest-axi`](https://github.com/JarvusInnovations/harvest-axi)                                  | Jarvus Innovations | Time tracking    | Review, log, and edit Harvest time entries by period - for yourself, your team, a project, or a client.                       |
 | [`specops`](https://github.com/JarvusInnovations/specops)                                          | Jarvus Innovations | Spec-driven dev  | Spec-driven development for agents - and a demo of shipping an AXI embedded in a skill, not a standalone npm executable.      |
 | [`gitsheets-axi`](https://github.com/JarvusInnovations/gitsheets/tree/main/packages/gitsheets-axi) | Jarvus Innovations | Git-backed data  | Read and mutate git-backed record sheets over the shell - TOON output, idempotent commits.                                    |
+| [`metabase-axi`](https://github.com/JarvusInnovations/metabase-axi)                                | Jarvus Innovations | Analytics / BI   | Query, explore, and export from Metabase over the shell - SQL/MBQL, saved questions, schema introspection, full-data export.  |
+| [`otter-axi`](https://github.com/JarvusInnovations/otter-axi)                                      | Jarvus Innovations | Meetings         | Find and pull Otter.ai meeting transcripts from the shell - wraps Otter.ai's hosted MCP server as a scriptable, headless CLI. |
 
 Built an AXI? Follow the [contributor workflow](CONTRIBUTING.md) to add it to this list.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -431,6 +431,34 @@
                     TOON output, idempotent commits.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/metabase-axi"
+                      ><code>metabase-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Analytics / BI</td>
+                  <td>
+                    Query, explore, and export from Metabase over the shell -
+                    SQL/MBQL, saved questions, schema introspection, full-data
+                    export.
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/JarvusInnovations/otter-axi"
+                      ><code>otter-axi</code></a
+                    >
+                  </td>
+                  <td>Jarvus Innovations</td>
+                  <td>Meetings</td>
+                  <td>
+                    Find and pull Otter.ai meeting transcripts from the shell -
+                    wraps Otter.ai's hosted MCP server as a scriptable, headless
+                    CLI.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## What changed

Adds two Jarvus Innovations AXIs to the Community catalog, in the two places it is maintained — the `README.md` table and the matching `docs/index.html` table on the axi.md site:

| AXI | Domain | What it does |
| --- | --- | --- |
| [`metabase-axi`](https://github.com/JarvusInnovations/metabase-axi) | Analytics / BI | Query, explore, and export from Metabase over the shell — SQL/MBQL, saved questions, schema introspection, full-data export. |
| [`otter-axi`](https://github.com/JarvusInnovations/otter-axi) | Meetings | Find and pull Otter.ai meeting transcripts from the shell — wraps Otter.ai's hosted MCP server as a scriptable, headless CLI. |

`otter-axi` is notable as an AXI that **wraps a public, hosted MCP server**: Otter's hosted MCP connector re-prompts for auth and can't be scripted, so otter-axi fronts that same sanctioned MCP server as a non-interactive CLI (`search`/`fetch`) with token-efficient TOON output — a demonstration that the AXI ergonomics layer can sit on top of an MCP backend.

Both rows are appended after `gitsheets-axi`; the README rows are space-padded to the table's fixed column widths. Docs-only — no code or SDK changes.

> Supersedes #54 (metabase-axi) and #55 (otter-axi), combined into one PR to avoid a merge-order conflict in the same table region.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

Validated through `git push no-mistakes`: review, test, document, and lint all passed with no findings. This PR contains only the two catalog files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
