### PR TITLE
feat(axi-sdk-js): add built-in self-update command

### DIFF
--- a/.no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi
+++ b/.no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+import { fileURLToPath } from "node:url";
+import { runAxiCli } from "../../../../../../packages/axi-sdk-js/src/index.js";
+
+process.argv[1] = fileURLToPath(import.meta.url);
+
+const latest = process.env.DEMO_AXI_LATEST ?? "0.1.0";
+globalThis.fetch = async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ version: latest }),
+});
+
+const commands = {
+  status: async () => ({ status: "ok" }),
+};
+
+if (process.env.DEMO_AXI_OVERRIDE_UPDATE === "1") {
+  commands.update = async () => ({ update: "tool-owned update handler" });
+}
+
+await runAxiCli({
+  description: "Demo AXI tool with no SDK update wiring",
+  version: "0.1.0",
+  topLevelHelp: "usage: demo-axi <command>\ncommands[1]: status\n",
+  home: async () => ({ demo: "home" }),
+  commands,
+});

--- a/.no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/package.json
+++ b/.no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@no-mistakes/demo-axi-update",
+  "version": "9.9.9",
+  "type": "module",
+  "bin": {
+    "demo-axi": "./bin/demo-axi"
+  }
+}

--- a/.no-mistakes/evidence/fm/axi-selfupdate-u8/e2e-transcript.txt
+++ b/.no-mistakes/evidence/fm/axi-selfupdate-u8/e2e-transcript.txt
@@ -1,0 +1,112 @@
+# AXI SDK built-in update end-to-end transcript
+
+Fixture package intentionally does not pass packageName and does not register an update command unless DEMO_AXI_OVERRIDE_UPDATE=1.
+The fixture is executed through vite-node so the transcript exercises packages/axi-sdk-js/src directly, with argv[1] normalized to the fixture entrypoint.
+
+## bare --help advertises the SDK-owned update command
+$ demo-axi --help
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi --help
+
+stdout:
+usage: demo-axi <command>
+commands[1]: status
+"built-in":
+  update: Upgrade `demo-axi` to the latest published version
+  "update --check": Report current vs latest without installing
+
+stderr:
+<empty>
+
+## update --help shows the built-in reference
+$ demo-axi update --help
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update --help
+
+stdout:
+command: update
+description: Upgrade `demo-axi` to the latest published npm version
+flags:
+  "--check": Report current vs latest and exit without installing
+examples[2]: demo-axi update,demo-axi update --check
+
+stderr:
+<empty>
+
+## update --check reports current vs latest without installing
+$ DEMO_AXI_LATEST=0.2.0 demo-axi update --check
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update --check
+
+stdout:
+update:
+  package: @no-mistakes/demo-axi-update
+  current: 0.1.0
+  latest: 0.2.0
+  available: true
+help[1]: Run `demo-axi update` to upgrade
+
+stderr:
+<empty>
+
+## update --dry-run is accepted as the check alias
+$ DEMO_AXI_LATEST=0.2.0 demo-axi update --dry-run
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update --dry-run
+
+stdout:
+update:
+  package: @no-mistakes/demo-axi-update
+  current: 0.1.0
+  latest: 0.2.0
+  available: true
+help[1]: Run `demo-axi update` to upgrade
+
+stderr:
+<empty>
+
+## unknown install method prints the manual command instead of guessing
+$ DEMO_AXI_LATEST=0.2.0 demo-axi update
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update
+
+stdout:
+update:
+  package: @no-mistakes/demo-axi-update
+  current: 0.1.0
+  latest: 0.2.0
+  available: true
+  action: manual
+  reason: Could not determine how this tool was installed
+  run: npm install -g @no-mistakes/demo-axi-update@latest
+help[1]: Run `npm install -g @no-mistakes/demo-axi-update@latest` to upgrade
+
+stderr:
+<empty>
+
+## already-latest update exits cleanly without installing
+$ DEMO_AXI_LATEST=0.1.0 demo-axi update
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update
+
+stdout:
+update: @no-mistakes/demo-axi-update is already on the latest version (0.1.0)
+
+stderr:
+<empty>
+
+## a tool-owned update command suppresses the built-in help footer
+$ DEMO_AXI_OVERRIDE_UPDATE=1 demo-axi --help
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi --help
+
+stdout:
+usage: demo-axi <command>
+commands[1]: status
+
+stderr:
+<empty>
+
+## a tool-owned update command receives update dispatch
+$ DEMO_AXI_OVERRIDE_UPDATE=1 demo-axi update
+# executed as: packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/demo-tool/bin/demo-axi update
+
+stdout:
+update: tool-owned update handler
+
+stderr:
+<empty>
+

--- a/.no-mistakes/evidence/fm/axi-selfupdate-u8/run-e2e.mjs
+++ b/.no-mistakes/evidence/fm/axi-selfupdate-u8/run-e2e.mjs
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const evidenceDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(evidenceDir, "../../../..");
+const viteNode = resolve(repoRoot, "packages/axi-sdk-js/node_modules/.bin/vite-node");
+const cli = resolve(evidenceDir, "demo-tool/bin/demo-axi");
+const transcriptPath = resolve(evidenceDir, "e2e-transcript.txt");
+
+const cases = [
+  {
+    title: "bare --help advertises the SDK-owned update command",
+    display: "demo-axi --help",
+    args: ["--help"],
+    env: {},
+    expect: ["usage: demo-axi <command>", "\"built-in\":", "update --check"],
+    reject: [],
+  },
+  {
+    title: "update --help shows the built-in reference",
+    display: "demo-axi update --help",
+    args: ["update", "--help"],
+    env: {},
+    expect: ["command: update", "description:", "\"--check\":", "examples[2]:"],
+    reject: [],
+  },
+  {
+    title: "update --check reports current vs latest without installing",
+    display: "DEMO_AXI_LATEST=0.2.0 demo-axi update --check",
+    args: ["update", "--check"],
+    env: { DEMO_AXI_LATEST: "0.2.0" },
+    expect: [
+      "package: @no-mistakes/demo-axi-update",
+      "current: 0.1.0",
+      "latest: 0.2.0",
+      "available: true",
+      "Run `demo-axi update` to upgrade",
+    ],
+    reject: ["running:"],
+  },
+  {
+    title: "update --dry-run is accepted as the check alias",
+    display: "DEMO_AXI_LATEST=0.2.0 demo-axi update --dry-run",
+    args: ["update", "--dry-run"],
+    env: { DEMO_AXI_LATEST: "0.2.0" },
+    expect: ["current: 0.1.0", "latest: 0.2.0", "available: true"],
+    reject: ["running:"],
+  },
+  {
+    title: "unknown install method prints the manual command instead of guessing",
+    display: "DEMO_AXI_LATEST=0.2.0 demo-axi update",
+    args: ["update"],
+    env: { DEMO_AXI_LATEST: "0.2.0" },
+    expect: [
+      "action: manual",
+      "reason: Could not determine how this tool was installed",
+      "run: npm install -g @no-mistakes/demo-axi-update@latest",
+    ],
+    reject: ["running:"],
+  },
+  {
+    title: "already-latest update exits cleanly without installing",
+    display: "DEMO_AXI_LATEST=0.1.0 demo-axi update",
+    args: ["update"],
+    env: { DEMO_AXI_LATEST: "0.1.0" },
+    expect: [
+      "update: @no-mistakes/demo-axi-update is already on the latest version (0.1.0)",
+    ],
+    reject: ["running:"],
+  },
+  {
+    title: "a tool-owned update command suppresses the built-in help footer",
+    display: "DEMO_AXI_OVERRIDE_UPDATE=1 demo-axi --help",
+    args: ["--help"],
+    env: { DEMO_AXI_OVERRIDE_UPDATE: "1" },
+    expect: ["usage: demo-axi <command>"],
+    reject: ["\"built-in\":", "update --check"],
+  },
+  {
+    title: "a tool-owned update command receives update dispatch",
+    display: "DEMO_AXI_OVERRIDE_UPDATE=1 demo-axi update",
+    args: ["update"],
+    env: { DEMO_AXI_OVERRIDE_UPDATE: "1" },
+    expect: ["update: tool-owned update handler"],
+    reject: ["current:", "latest:", "running:"],
+  },
+];
+
+const transcript = [
+  "# AXI SDK built-in update end-to-end transcript",
+  "",
+  "Fixture package intentionally does not pass packageName and does not register an update command unless DEMO_AXI_OVERRIDE_UPDATE=1.",
+  "The fixture is executed through vite-node so the transcript exercises packages/axi-sdk-js/src directly, with argv[1] normalized to the fixture entrypoint.",
+  "",
+];
+
+for (const testCase of cases) {
+  const env = { ...process.env, ...testCase.env };
+  const { stdout, stderr } = await execFileAsync(viteNode, [cli, ...testCase.args], {
+    cwd: repoRoot,
+    env,
+  });
+
+  for (const expected of testCase.expect) {
+    assert.match(stdout, new RegExp(escapeRegExp(expected)), testCase.title);
+  }
+  for (const rejected of testCase.reject) {
+    assert.doesNotMatch(stdout + stderr, new RegExp(escapeRegExp(rejected)), testCase.title);
+  }
+
+  transcript.push(`## ${testCase.title}`);
+  transcript.push(`$ ${testCase.display}`);
+  transcript.push(`# executed as: ${relative(repoRoot, viteNode)} ${relative(repoRoot, cli)} ${testCase.args.join(" ")}`.trim());
+  transcript.push("");
+  transcript.push("stdout:");
+  transcript.push(stdout.trimEnd() || "<empty>");
+  transcript.push("");
+  transcript.push("stderr:");
+  transcript.push(stderr.trimEnd() || "<empty>");
+  transcript.push("");
+}
+
+await import("node:fs/promises").then(({ writeFile }) =>
+  writeFile(transcriptPath, `${transcript.join("\n")}\n`, "utf8"),
+);
+
+console.log(relative(repoRoot, transcriptPath));
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This file provides guidance to AI agents when working with code in this reposito
 
 AXI (Agent eXperience Interface) defines 10 ergonomic principles for building CLI tools that AI agents use via shell execution. This repo contains:
 
+- **`packages/axi-sdk-js/`** — Shared Node.js SDK every `*-axi` CLI builds on. `runAxiCli()` provides built-in commands for all tools: `--help`, `-v`/`--version`, and `update` (self-update). `update` is a reserved command name; a tool may shadow it by registering its own handler.
 - **`bench-github/`** — Benchmark harness that compares gh-axi vs gh CLI vs GitHub MCP across 17 agent tasks, graded by an LLM judge.
 - **`bench-browser/`** — Benchmark harness that compares browser automation tools (agent-browser, pinchtab, chrome-devtools-mcp) across 16 browsing tasks.
 - **`.agents/skills/axi/SKILL.md`** — The AXI skill definition (installable via `npx skills add kunchenguid/axi`).

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -19,6 +19,8 @@ If you want agent session context plumbing, wire `installSessionStartHooks()` in
 
 `runAxiCli()` assumes a command-first CLI shape: `<bin> <command> ...args ...flags`. Bare `--help` is still supported, but flags are not allowed before the top-level command.
 
+Every tool built on `runAxiCli()` also gets a built-in `update` self-update command for free (alongside `--help` and `-v`/`--version`). See [Built-in self-update](#built-in-self-update).
+
 If your executable boundary needs to normalize loader-specific arguments before dispatch, pass `argv` explicitly to `runAxiCli()` instead of relying on `process.argv.slice(2)`.
 
 ## Quick Start
@@ -51,13 +53,54 @@ await runAxiCli({
 });
 ```
 
+## Built-in self-update
+
+`runAxiCli()` reserves `update` as a built-in command, so every tool gains `<tool> update` and `<tool> update --check` with **zero per-tool code**.
+
+```sh
+$ gh-axi update --check
+update:
+  package: gh-axi
+  current: 1.2.3
+  latest: 1.3.0
+  available: true
+help[1]: Run `gh-axi update` to upgrade
+
+$ gh-axi update
+running: npm install -g gh-axi@latest
+update: gh-axi upgraded 1.2.3 -> 1.3.0
+command: npm install -g gh-axi@latest
+```
+
+How it works:
+
+- **Identity is auto-derived.** The package name and version are read from the nearest `package.json` (walking up from the realpath-resolved entrypoint). `version` from `runAxiCli()` is preferred when present. No wiring needed.
+- **The latest version comes from the registry.** It queries `https://registry.npmjs.org/<pkg>/latest`, falling back to `npm view <pkg> version`, and compares with proper semver. Network, registry, and not-found failures surface as structured `AxiError`s.
+- **The upgrade matches the install method**, detected from the entrypoint path and environment:
+  - npm global → `npm install -g <pkg>@latest`
+  - pnpm global → `pnpm add -g <pkg>@latest`
+  - Homebrew (`/Cellar/`) → `brew upgrade <formula>`
+  - npx / ephemeral cache → reports that `npx -y <tool>` already runs the latest (print-only)
+  - unknown → prints the recommended command without guessing (print-only)
+- **`update --check`** (a/k/a `--dry-run`) reports current vs latest and whether an update is available, installing nothing. When already on the latest version, `update` reports up-to-date and exits 0.
+
+`update` is a **reserved command name**. A tool that registers its own `update` in `commands` keeps full control - the built-in never shadows it. Pass `packageName` to `runAxiCli()` only as an escape hatch when the package name cannot be derived from `package.json`:
+
+```ts
+await runAxiCli({
+  // ...other options
+  version: "1.2.3",
+  packageName: "gh-axi", // optional override; normally auto-derived
+});
+```
+
 ## Reference
 
 `axi-sdk-js` is a library package. In normal use, `runAxiCli()` should be the main entry point.
 
-| API           | Description                                                                                                                                                                  |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, lazy context resolution, home header injection, TOON serialization, and standardized errors |
+| API           | Description                                                                                                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, the built-in `update` command, lazy context resolution, home header injection, TOON serialization, and errors |
 
 ### Advanced Exports
 
@@ -66,6 +109,7 @@ Most AXI authors should not need these directly.
 | API                                      | Description                                                                                     |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `AxiError`                               | Throw structured AXI errors from command handlers                                               |
+| `runUpdate()`                            | The built-in self-update flow (registry lookup, install-method detection, upgrade)              |
 | `installSessionStartHooks()`             | Install or repair Claude Code hooks, Codex hooks, and OpenCode ambient context plugins directly |
 | `resolvePortableHookCommand()`           | Resolve a hook command to a safe binary name or absolute path                                   |
 | `PortableHookCommandContext`             | Context for resolving portable hook commands                                                    |

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -56,6 +56,7 @@ await runAxiCli({
 ## Built-in self-update
 
 `runAxiCli()` reserves `update` as a built-in command, so every tool gains `<tool> update` and `<tool> update --check` with **zero per-tool code**.
+`<tool> update --dry-run` is accepted as an alias for `--check`.
 
 ```sh
 $ gh-axi update --check
@@ -77,12 +78,13 @@ How it works:
 - **Identity is auto-derived.** The package name and version are read from the nearest `package.json` (walking up from the realpath-resolved entrypoint). `version` from `runAxiCli()` is preferred when present. No wiring needed.
 - **The latest version comes from the registry.** It queries `https://registry.npmjs.org/<pkg>/latest`, falling back to `npm view <pkg> version`, and compares with proper semver. Network, registry, and not-found failures surface as structured `AxiError`s.
 - **The upgrade matches the install method**, detected from the entrypoint path and environment:
-  - npm global → `npm install -g <pkg>@latest`
-  - pnpm global → `pnpm add -g <pkg>@latest`
-  - Homebrew (`/Cellar/`) → `brew upgrade <formula>`
-  - npx / ephemeral cache → reports that `npx -y <tool>` already runs the latest (print-only)
-  - unknown → prints the recommended command without guessing (print-only)
+  - npm global -> `npm install -g <pkg>@latest`
+  - pnpm global -> `pnpm add -g <pkg>@latest`
+  - Homebrew (`/Cellar/`) -> `brew upgrade <formula>`
+  - npx / ephemeral cache -> reports that `npx -y <pkg>@latest` already runs the latest (print-only)
+  - unknown -> prints the recommended command without guessing (print-only)
 - **`update --check`** (a/k/a `--dry-run`) reports current vs latest and whether an update is available, installing nothing. When already on the latest version, `update` reports up-to-date and exits 0.
+- **Discoverability is SDK-owned.** Bare `--help` gets a compact built-in command footer when the tool has not registered its own `update`, and `<tool> update --help` shows the command reference.
 
 `update` is a **reserved command name**. A tool that registers its own `update` in `commands` keeps full control - the built-in never shadows it. Pass `packageName` to `runAxiCli()` only as an escape hatch when the package name cannot be derived from `package.json`:
 
@@ -109,7 +111,11 @@ Most AXI authors should not need these directly.
 | API                                      | Description                                                                                     |
 | ---------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | `AxiError`                               | Throw structured AXI errors from command handlers                                               |
+| `RESERVED_COMMANDS`                      | SDK-owned built-in command names, currently `update`                                            |
 | `runUpdate()`                            | The built-in self-update flow (registry lookup, install-method detection, upgrade)              |
+| `fetchLatestVersion()`                   | Resolve the latest npm version through the registry endpoint with an `npm view` fallback        |
+| `detectInstallMethod()`, `planUpgrade()` | Inspect an entrypoint path and map it to the upgrade command the built-in updater would use     |
+| `compareSemver()`, `isUpdateAvailable()` | Semver helpers used by the updater, including prerelease ordering                               |
 | `installSessionStartHooks()`             | Install or repair Claude Code hooks, Codex hooks, and OpenCode ambient context plugins directly |
 | `resolvePortableHookCommand()`           | Resolve a hook command to a safe binary name or absolute path                                   |
 | `PortableHookCommandContext`             | Context for resolving portable hook commands                                                    |

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -7,6 +7,13 @@ import {
   type AxiRenderable,
   type AxiStructuredOutput,
 } from "./output.js";
+import { runUpdate } from "./update.js";
+
+/**
+ * Command names reserved by the SDK as built-ins. A tool may shadow one by
+ * registering its own handler in `options.commands`.
+ */
+export const RESERVED_COMMANDS = ["update"] as const;
 
 type MaybePromise<T> = T | Promise<T>;
 
@@ -23,6 +30,11 @@ export interface AxiResolveContextInput {
 export interface AxiCliOptions<TContext = undefined> {
   description: string;
   version?: string;
+  /**
+   * npm package name override for the built-in `update` command. Defaults to the
+   * name resolved from the nearest `package.json`, so most tools never set it.
+   */
+  packageName?: string;
   argv?: string[];
   topLevelHelp: string;
   commands: Record<string, AxiCliCommand<TContext>>;
@@ -69,6 +81,9 @@ export async function runAxiCli<TContext = undefined>(
 
   if (argv.length === 1 && argv[0] === "--help") {
     stdout.write(options.topLevelHelp);
+    if (!options.commands.update) {
+      stdout.write(builtinCommandsHelp());
+    }
     return;
   }
 
@@ -102,6 +117,13 @@ export async function runAxiCli<TContext = undefined>(
   }
 
   const args = argv.slice(1);
+
+  // `update` is a reserved built-in. A tool may shadow it by registering its own
+  // handler; otherwise the SDK handles the self-update.
+  if (command === "update" && !options.commands.update) {
+    await runBuiltinUpdate(args, stdout, options);
+    return;
+  }
 
   if (args.includes("--help")) {
     const help = options.getCommandHelp?.(command);
@@ -140,6 +162,57 @@ async function runHandler<TContext>(
     stdout.write(formatted.output);
     process.exitCode = formatted.exitCode;
   }
+}
+
+async function runBuiltinUpdate<TContext>(
+  args: string[],
+  stdout: { write: (chunk: string) => unknown },
+  options: AxiCliOptions<TContext>,
+): Promise<void> {
+  if (args.includes("--help")) {
+    stdout.write(builtinUpdateHelp());
+    return;
+  }
+
+  try {
+    const output = await runUpdate({
+      args,
+      stdout,
+      packageName: options.packageName,
+      version: options.version,
+    });
+    stdout.write(`${renderOutput(output)}\n`);
+  } catch (error) {
+    const formatted = (options.formatError ?? defaultFormatError)(error);
+    stdout.write(formatted.output);
+    process.exitCode = formatted.exitCode;
+  }
+}
+
+function resolveBinName(): string {
+  return basename(process.argv[1] ?? "tool") || "tool";
+}
+
+function builtinCommandsHelp(): string {
+  const bin = resolveBinName();
+  return `${renderOutput({
+    "built-in": {
+      update: `Upgrade \`${bin}\` to the latest published version`,
+      "update --check": "Report current vs latest without installing",
+    },
+  })}\n`;
+}
+
+function builtinUpdateHelp(): string {
+  const bin = resolveBinName();
+  return `${renderOutput({
+    command: "update",
+    description: `Upgrade \`${bin}\` to the latest published npm version`,
+    flags: {
+      "--check": "Report current vs latest and exit without installing",
+    },
+    examples: [`${bin} update`, `${bin} update --check`],
+  })}\n`;
 }
 
 function renderLeadingFlagError(flag: string): string {

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -169,7 +169,7 @@ async function runBuiltinUpdate<TContext>(
   stdout: { write: (chunk: string) => unknown },
   options: AxiCliOptions<TContext>,
 ): Promise<void> {
-  if (args.includes("--help")) {
+  if (args.length === 1 && args[0] === "--help") {
     stdout.write(builtinUpdateHelp());
     return;
   }

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -82,6 +82,12 @@ export async function runAxiCli<TContext = undefined>(
   if (argv.length === 1 && argv[0] === "--help") {
     stdout.write(options.topLevelHelp);
     if (!options.commands.update) {
+      if (
+        options.topLevelHelp.length > 0 &&
+        !options.topLevelHelp.endsWith("\n")
+      ) {
+        stdout.write("\n");
+      }
       stdout.write(builtinCommandsHelp());
     }
     return;

--- a/packages/axi-sdk-js/src/index.ts
+++ b/packages/axi-sdk-js/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./cli.js";
 export * from "./errors.js";
 export * from "./hooks.js";
+export * from "./update.js";

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -1,0 +1,550 @@
+import { spawn } from "node:child_process";
+import { execFile } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { promisify } from "node:util";
+import { AxiError } from "./errors.js";
+import type { AxiRenderable } from "./output.js";
+
+const execFileAsync = promisify(execFile);
+
+const REGISTRY_BASE = "https://registry.npmjs.org";
+
+/**
+ * Minimal `fetch`-like shape so registry lookups stay decoupled from the global
+ * `fetch` typings and trivially mockable in tests.
+ */
+export type FetchLike = (
+  input: string,
+  init?: { headers?: Record<string, string> },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json: () => Promise<unknown>;
+}>;
+
+export interface ParsedSemver {
+  major: number;
+  minor: number;
+  patch: number;
+  prerelease: string[];
+}
+
+/** Parse a semver string. Returns `null` when the version is not valid semver. */
+export function parseSemver(version: string): ParsedSemver | null {
+  const match =
+    /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-.]+))?(?:\+[0-9A-Za-z-.]+)?$/.exec(
+      version.trim(),
+    );
+  if (!match) {
+    return null;
+  }
+
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4] ? match[4].split(".") : [],
+  };
+}
+
+function comparePrerelease(a: string[], b: string[]): number {
+  // A version without prerelease identifiers is greater than one with them.
+  if (a.length === 0 && b.length === 0) return 0;
+  if (a.length === 0) return 1;
+  if (b.length === 0) return -1;
+
+  const length = Math.max(a.length, b.length);
+  for (let index = 0; index < length; index += 1) {
+    if (index >= a.length) return -1;
+    if (index >= b.length) return 1;
+
+    const left = a[index];
+    const right = b[index];
+    const leftNumeric = /^\d+$/.test(left);
+    const rightNumeric = /^\d+$/.test(right);
+
+    if (leftNumeric && rightNumeric) {
+      const delta = Number(left) - Number(right);
+      if (delta !== 0) return delta < 0 ? -1 : 1;
+    } else if (leftNumeric) {
+      return -1;
+    } else if (rightNumeric) {
+      return 1;
+    } else if (left !== right) {
+      return left < right ? -1 : 1;
+    }
+  }
+
+  return 0;
+}
+
+/**
+ * Compare two semver strings. Returns -1, 0, or 1. Unparseable versions fall
+ * back to a deterministic lexical comparison so the caller never throws.
+ */
+export function compareSemver(a: string, b: string): number {
+  const parsedA = parseSemver(a);
+  const parsedB = parseSemver(b);
+
+  if (!parsedA || !parsedB) {
+    if (a === b) return 0;
+    return a < b ? -1 : 1;
+  }
+
+  if (parsedA.major !== parsedB.major) {
+    return parsedA.major < parsedB.major ? -1 : 1;
+  }
+  if (parsedA.minor !== parsedB.minor) {
+    return parsedA.minor < parsedB.minor ? -1 : 1;
+  }
+  if (parsedA.patch !== parsedB.patch) {
+    return parsedA.patch < parsedB.patch ? -1 : 1;
+  }
+
+  return comparePrerelease(parsedA.prerelease, parsedB.prerelease);
+}
+
+/** True when `latest` is a strictly newer version than `current`. */
+export function isUpdateAvailable(current: string, latest: string): boolean {
+  return compareSemver(latest, current) > 0;
+}
+
+export interface PackageIdentity {
+  packageName?: string;
+  version?: string;
+  packageJsonPath?: string;
+}
+
+export interface IdentityFs {
+  existsSync: (path: string) => boolean;
+  readFileSync: (path: string, encoding: "utf-8") => string;
+}
+
+const nodeFs: IdentityFs = {
+  existsSync,
+  readFileSync: (path, encoding) => readFileSync(path, encoding),
+};
+
+/**
+ * Walk up from `startPath` to the nearest `package.json` that declares a name,
+ * returning the tool's npm package name and version. This is how a tool gains
+ * `update` with zero per-tool wiring: its own published `package.json` ships
+ * inside the install tree next to the running entrypoint.
+ */
+export function readNearestPackageJson(
+  startPath: string,
+  fs: IdentityFs = nodeFs,
+): PackageIdentity {
+  let dir = dirname(startPath);
+  let previous = "";
+
+  while (dir !== previous) {
+    const packageJsonPath = join(dir, "package.json");
+    if (fs.existsSync(packageJsonPath)) {
+      try {
+        const parsed = JSON.parse(
+          fs.readFileSync(packageJsonPath, "utf-8"),
+        ) as {
+          name?: unknown;
+          version?: unknown;
+        };
+        if (typeof parsed.name === "string" && parsed.name.length > 0) {
+          return {
+            packageName: parsed.name,
+            version:
+              typeof parsed.version === "string" ? parsed.version : undefined,
+            packageJsonPath,
+          };
+        }
+      } catch {
+        // Malformed package.json: keep walking upward.
+      }
+    }
+
+    previous = dir;
+    dir = dirname(dir);
+  }
+
+  return {};
+}
+
+export type InstallMethod =
+  | { kind: "npm-global" }
+  | { kind: "pnpm-global" }
+  | { kind: "homebrew"; formula: string | null }
+  | { kind: "npx" }
+  | { kind: "unknown" };
+
+/**
+ * Infer how the running tool was installed from its realpath-resolved entry and
+ * the environment. Order matters: ephemeral caches and Homebrew Cellars are
+ * checked before the generic global-install layouts they can contain.
+ */
+export function detectInstallMethod(options: {
+  entry: string;
+  env?: NodeJS.ProcessEnv;
+}): InstallMethod {
+  const env = options.env ?? process.env;
+  const path = options.entry.replaceAll("\\", "/");
+
+  // npx / ephemeral runner caches: nothing is persistently installed.
+  if (
+    path.includes("/_npx/") ||
+    /\/dlx-[^/]+\//.test(path) ||
+    path.includes("/pnpm/dlx/") ||
+    path.includes("/bun/install/cache/")
+  ) {
+    return { kind: "npx" };
+  }
+
+  // Homebrew formula: the Cellar segment names the formula.
+  const cellar = path.match(/\/Cellar\/([^/]+)\//);
+  if (cellar) {
+    return { kind: "homebrew", formula: cellar[1] };
+  }
+
+  // pnpm global store (virtual store + global root, or PNPM_HOME).
+  const pnpmHome = env.PNPM_HOME?.replaceAll("\\", "/");
+  if (
+    path.includes("/pnpm/global/") ||
+    path.includes("/pnpm-global/") ||
+    path.includes("/.pnpm/") ||
+    /\/Library\/pnpm\//.test(path) ||
+    (pnpmHome && pnpmHome.length > 0 && path.startsWith(pnpmHome))
+  ) {
+    return { kind: "pnpm-global" };
+  }
+
+  // npm global (also covers npm-installed-under-Homebrew-node).
+  if (path.includes("/lib/node_modules/")) {
+    return { kind: "npm-global" };
+  }
+
+  return { kind: "unknown" };
+}
+
+export interface UpgradePlan {
+  method: InstallMethod["kind"];
+  /** Human-readable command, used both for announcing and print-only output. */
+  command: string;
+  /** Spawn argv, or `null` when the upgrade must not be run automatically. */
+  argv: string[] | null;
+  /** Why the plan is print-only, when applicable. */
+  note?: string;
+}
+
+/** Map a detected install method to the exact upgrade command for it. */
+export function planUpgrade(
+  method: InstallMethod,
+  packageName: string,
+): UpgradePlan {
+  switch (method.kind) {
+    case "npm-global":
+      return {
+        method: method.kind,
+        command: `npm install -g ${packageName}@latest`,
+        argv: ["npm", "install", "-g", `${packageName}@latest`],
+      };
+    case "pnpm-global":
+      return {
+        method: method.kind,
+        command: `pnpm add -g ${packageName}@latest`,
+        argv: ["pnpm", "add", "-g", `${packageName}@latest`],
+      };
+    case "homebrew":
+      if (method.formula) {
+        return {
+          method: method.kind,
+          command: `brew upgrade ${method.formula}`,
+          argv: ["brew", "upgrade", method.formula],
+        };
+      }
+      return {
+        method: method.kind,
+        command: `brew upgrade ${packageName}`,
+        argv: null,
+        note: "Could not determine the Homebrew formula automatically",
+      };
+    case "npx":
+      return {
+        method: method.kind,
+        command: `npx -y ${packageName}@latest`,
+        argv: null,
+        note: "npx always runs the latest published version, so no install is needed",
+      };
+    case "unknown":
+      return {
+        method: method.kind,
+        command: `npm install -g ${packageName}@latest`,
+        argv: null,
+        note: "Could not determine how this tool was installed",
+      };
+  }
+}
+
+async function npmViewVersion(packageName: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "npm",
+      ["view", packageName, "version"],
+      { timeout: 20_000 },
+    );
+    const version = stdout.trim();
+    return version.length > 0 ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+function registryPath(packageName: string): string {
+  // Scoped names encode only the slash; the registry expects a literal `@`.
+  return packageName.startsWith("@")
+    ? packageName.replace("/", "%2f")
+    : packageName;
+}
+
+function notPublishedError(packageName: string): AxiError {
+  return new AxiError(
+    `${packageName} is not published to the npm registry`,
+    "UPDATE_ERROR",
+    [
+      "Confirm the package name is correct",
+      `Run \`npm view ${packageName} version\` to check manually`,
+    ],
+  );
+}
+
+export interface FetchLatestOptions {
+  fetchImpl?: FetchLike | null;
+  npmView?: (packageName: string) => Promise<string | null>;
+}
+
+/**
+ * Resolve the latest published version. Prefers the registry HTTP endpoint and
+ * falls back to `npm view`. Network, registry, and not-found failures surface as
+ * `AxiError` with actionable suggestions, never a raw stack trace.
+ */
+export async function fetchLatestVersion(
+  packageName: string,
+  options: FetchLatestOptions = {},
+): Promise<string> {
+  const fetchImpl =
+    options.fetchImpl === undefined
+      ? (globalThis.fetch as unknown as FetchLike | undefined)
+      : (options.fetchImpl ?? undefined);
+
+  if (typeof fetchImpl === "function") {
+    try {
+      const response = await fetchImpl(
+        `${REGISTRY_BASE}/${registryPath(packageName)}/latest`,
+        { headers: { accept: "application/json" } },
+      );
+      if (response.ok) {
+        const data = (await response.json()) as { version?: unknown };
+        if (typeof data.version === "string" && data.version.length > 0) {
+          return data.version;
+        }
+      } else if (response.status === 404) {
+        throw notPublishedError(packageName);
+      }
+    } catch (error) {
+      if (error instanceof AxiError) {
+        throw error;
+      }
+      // Network/parse failure: fall through to the npm CLI fallback.
+    }
+  }
+
+  const viewed = await (options.npmView ?? npmViewVersion)(packageName);
+  if (viewed) {
+    return viewed;
+  }
+
+  throw new AxiError(
+    `Could not reach the npm registry to check for updates to ${packageName}`,
+    "UPDATE_ERROR",
+    [
+      "Check your network connection and try again",
+      `Run \`npm view ${packageName} version\` to check manually`,
+    ],
+  );
+}
+
+export interface InstallResult {
+  ok: boolean;
+  message?: string;
+}
+
+async function defaultRunInstall(
+  plan: UpgradePlan,
+  stdout: { write: (chunk: string) => unknown },
+): Promise<InstallResult> {
+  const argv = plan.argv;
+  if (!argv || argv.length === 0) {
+    return { ok: false, message: "No runnable upgrade command" };
+  }
+
+  // Announce the command, then stream the installer's output straight through.
+  stdout.write(`running: ${plan.command}\n`);
+
+  return new Promise<InstallResult>((resolve) => {
+    const [command, ...args] = argv;
+    const child = spawn(command, args, { stdio: "inherit", shell: false });
+    child.on("error", (error) => {
+      resolve({ ok: false, message: error.message });
+    });
+    child.on("close", (code) => {
+      resolve(
+        code === 0
+          ? { ok: true }
+          : { ok: false, message: `${plan.command} exited with code ${code}` },
+      );
+    });
+  });
+}
+
+function binNameFromArgv(invokedAs: string | undefined): string {
+  return basename(invokedAs ?? "tool") || "tool";
+}
+
+function resolveEntry(
+  invokedAs: string | undefined,
+  realpath: (path: string) => string,
+): string | undefined {
+  if (!invokedAs) {
+    return undefined;
+  }
+  try {
+    return realpath(invokedAs);
+  } catch {
+    return invokedAs;
+  }
+}
+
+export interface RunUpdateOptions {
+  /** Args after the `update` command (e.g. `["--check"]`). */
+  args: string[];
+  stdout: { write: (chunk: string) => unknown };
+  /** Explicit npm package name override (escape hatch). */
+  packageName?: string;
+  /** Current version, normally `options.version` from `runAxiCli`. */
+  version?: string;
+
+  // Injectable seams (default to real implementations).
+  invokedAs?: string;
+  env?: NodeJS.ProcessEnv;
+  realpath?: (path: string) => string;
+  fs?: IdentityFs;
+  fetchLatest?: (packageName: string) => Promise<string>;
+  runInstall?: (
+    plan: UpgradePlan,
+    stdout: { write: (chunk: string) => unknown },
+  ) => Promise<InstallResult>;
+}
+
+function isCheckOnly(args: string[]): boolean {
+  return args.includes("--check") || args.includes("--dry-run");
+}
+
+/**
+ * Execute the built-in `update` flow: resolve identity, query the registry,
+ * compare versions, and (unless `--check`) upgrade via the detected install
+ * method. Returns the renderable result; throws `AxiError` on failure.
+ */
+export async function runUpdate(
+  options: RunUpdateOptions,
+): Promise<AxiRenderable> {
+  const checkOnly = isCheckOnly(options.args);
+  const invokedAs = options.invokedAs ?? process.argv[1];
+  const binName = binNameFromArgv(invokedAs);
+  const realpath = options.realpath ?? ((path: string) => realpathSync(path));
+  const entry = resolveEntry(invokedAs, realpath);
+
+  const fromPackageJson = entry
+    ? readNearestPackageJson(entry, options.fs ?? nodeFs)
+    : {};
+  const packageName = options.packageName ?? fromPackageJson.packageName;
+  const current = options.version ?? fromPackageJson.version;
+
+  if (!packageName) {
+    throw new AxiError(
+      "Could not determine the package name to update",
+      "UPDATE_ERROR",
+      [
+        "Reinstall the tool from npm so its package.json is available",
+        "Tool authors can pass `packageName` to runAxiCli()",
+      ],
+    );
+  }
+
+  if (!current) {
+    throw new AxiError(
+      `Could not determine the current version of ${packageName}`,
+      "UPDATE_ERROR",
+      [
+        "Reinstall the tool from npm so its version is available",
+        "Tool authors can pass `version` to runAxiCli()",
+      ],
+    );
+  }
+
+  const fetchLatest =
+    options.fetchLatest ?? ((name: string) => fetchLatestVersion(name));
+  const latest = await fetchLatest(packageName);
+  const available = isUpdateAvailable(current, latest);
+
+  if (checkOnly) {
+    const output: AxiRenderable = {
+      update: { package: packageName, current, latest, available },
+    };
+    if (available) {
+      output.help = [`Run \`${binName} update\` to upgrade`];
+    }
+    return output;
+  }
+
+  if (!available) {
+    return {
+      update: `${packageName} is already on the latest version (${current})`,
+    };
+  }
+
+  const method: InstallMethod = entry
+    ? detectInstallMethod({ entry, env: options.env })
+    : { kind: "unknown" };
+  const plan = planUpgrade(method, packageName);
+
+  if (!plan.argv) {
+    const help =
+      method.kind === "npx"
+        ? `Re-run with \`${plan.command}\` to use the latest version`
+        : `Run \`${plan.command}\` to upgrade`;
+    return {
+      update: {
+        package: packageName,
+        current,
+        latest,
+        available: true,
+        action: "manual",
+        ...(plan.note ? { reason: plan.note } : {}),
+        run: plan.command,
+      },
+      help: [help],
+    };
+  }
+
+  const runInstall = options.runInstall ?? defaultRunInstall;
+  const result = await runInstall(plan, options.stdout);
+  if (!result.ok) {
+    throw new AxiError(`Failed to upgrade ${packageName}`, "UPDATE_ERROR", [
+      `Run \`${plan.command}\` manually`,
+      ...(result.message ? [result.message] : []),
+    ]);
+  }
+
+  return {
+    update: `${packageName} upgraded ${current} -> ${latest}`,
+    command: plan.command,
+  };
+}

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -24,6 +24,7 @@ export type FetchLike = (
   json: () => Promise<unknown>;
 }>;
 
+/** Structured semver components returned by `parseSemver()`. */
 export interface ParsedSemver {
   major: number;
   minor: number;
@@ -111,12 +112,17 @@ export function isUpdateAvailable(current: string, latest: string): boolean {
   return compareSemver(latest, current) > 0;
 }
 
+/** Package metadata resolved from the nearest named `package.json`. */
 export interface PackageIdentity {
+  /** npm package name, when a named package.json was found. */
   packageName?: string;
+  /** package.json version, when declared. */
   version?: string;
+  /** Absolute path to the package.json that supplied the identity. */
   packageJsonPath?: string;
 }
 
+/** Small filesystem seam used by updater tests and custom embedders. */
 export interface IdentityFs {
   existsSync: (path: string) => boolean;
   readFileSync: (path: string, encoding: "utf-8") => string;
@@ -170,6 +176,7 @@ export function readNearestPackageJson(
   return {};
 }
 
+/** Installation source inferred from the realpath-resolved CLI entrypoint. */
 export type InstallMethod =
   | { kind: "npm-global" }
   | { kind: "pnpm-global" }
@@ -268,10 +275,7 @@ function homebrewCellarRoots(env: NodeJS.ProcessEnv): string[] {
   return [...new Set(roots)];
 }
 
-function isKnownPnpmGlobalStore(
-  path: string,
-  env: NodeJS.ProcessEnv,
-): boolean {
+function isKnownPnpmGlobalStore(path: string, env: NodeJS.ProcessEnv): boolean {
   return pnpmGlobalStoreRoots(env).some((root) => {
     if (!isPathInsideRoot(path, root)) {
       return false;
@@ -383,6 +387,7 @@ function versionManagerNodeRoots(env: NodeJS.ProcessEnv): string[] {
   return [...new Set(roots)];
 }
 
+/** Upgrade command selected for a detected install method. */
 export interface UpgradePlan {
   method: InstallMethod["kind"];
   /** Human-readable command, used both for announcing and print-only output. */
@@ -506,10 +511,15 @@ function notPublishedError(packageName: string): AxiError {
 
 class RegistryNotFoundError extends Error {}
 
+/** Injection points for fetching the latest published npm version. */
 export interface FetchLatestOptions {
+  /** Custom fetch implementation. Pass `null` to skip HTTP and use npm only. */
   fetchImpl?: FetchLike | null;
+  /** Custom `npm view` fallback. */
   npmView?: (packageName: string) => Promise<string | null>;
+  /** Registry HTTP timeout in milliseconds. */
   fetchTimeoutMs?: number;
+  /** Platform used when invoking npm through the fallback path. */
   platform?: NodeJS.Platform;
 }
 
@@ -616,11 +626,13 @@ export async function fetchLatestVersion(
   );
 }
 
+/** Result returned by the install runner used by `runUpdate()`. */
 export interface InstallResult {
   ok: boolean;
   message?: string;
 }
 
+/** Runtime context passed to a custom install runner. */
 export interface RunInstallContext {
   platform: NodeJS.Platform;
 }
@@ -725,26 +737,34 @@ function homebrewUpgradeOutput(options: {
   };
 }
 
+/** Options for invoking the built-in self-update flow directly. */
 export interface RunUpdateOptions {
   /** Args after the `update` command (e.g. `["--check"]`). */
   args: string[];
+  /** Output stream used for the `running:` announcement. */
   stdout: { write: (chunk: string) => unknown };
   /** Explicit npm package name override (escape hatch). */
   packageName?: string;
   /** Current version, normally `options.version` from `runAxiCli`. */
   version?: string;
 
-  // Injectable seams (default to real implementations).
+  /** CLI entrypoint path, normally `process.argv[1]`. */
   invokedAs?: string;
+  /** Environment used for install-method detection. */
   env?: NodeJS.ProcessEnv;
+  /** Realpath resolver for the invoked entrypoint. */
   realpath?: (path: string) => string;
+  /** Filesystem seam used to read package metadata. */
   fs?: IdentityFs;
+  /** Latest-version resolver. */
   fetchLatest?: (packageName: string) => Promise<string>;
+  /** Installer seam. Defaults to spawning the planned package-manager command. */
   runInstall?: (
     plan: UpgradePlan,
     stdout: { write: (chunk: string) => unknown },
     context: RunInstallContext,
   ) => Promise<InstallResult>;
+  /** Platform used for package-manager command shims. */
   platform?: NodeJS.Platform;
 }
 

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -199,14 +199,13 @@ export function detectInstallMethod(options: {
     return { kind: "npx" };
   }
 
-  // Homebrew formula: the Cellar segment names the formula.
-  const cellar = path.match(/\/Cellar\/([^/]+)\//);
-  if (cellar) {
-    return { kind: "homebrew", formula: cellar[1] };
+  const homebrewFormula = homebrewFormulaFromPath(path, env);
+  if (homebrewFormula) {
+    return { kind: "homebrew", formula: homebrewFormula };
   }
 
   const pnpmHome = normalizePathRoot(env.PNPM_HOME);
-  if (isPathInsideRoot(path, pnpmHome) || isKnownPnpmGlobalStore(path)) {
+  if (isPathInsideRoot(path, pnpmHome) || isKnownPnpmGlobalStore(path, env)) {
     return { kind: "pnpm-global" };
   }
 
@@ -227,12 +226,77 @@ function isPathInsideRoot(path: string, root: string | undefined): boolean {
   return root !== undefined && (path === root || path.startsWith(`${root}/`));
 }
 
-function isKnownPnpmGlobalStore(path: string): boolean {
-  return (
-    /\/Library\/pnpm\/global\/\d+\/\.pnpm\//.test(path) ||
-    /\/\.local\/share\/pnpm\/global\/\d+\/\.pnpm\//.test(path) ||
-    /\/AppData\/Local\/pnpm\/global\/\d+\/\.pnpm\//.test(path)
-  );
+function homebrewFormulaFromPath(
+  path: string,
+  env: NodeJS.ProcessEnv,
+): string | null {
+  for (const root of homebrewCellarRoots(env)) {
+    if (!isPathInsideRoot(path, root)) {
+      continue;
+    }
+
+    const relative = path.slice(root.length).replace(/^\/+/, "");
+    const formula = relative.split("/")[0];
+    if (formula) {
+      return formula;
+    }
+  }
+
+  return null;
+}
+
+function homebrewCellarRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots: string[] = [];
+  const explicitCellar = normalizePathRoot(env.HOMEBREW_CELLAR);
+  if (explicitCellar) {
+    roots.push(explicitCellar);
+  }
+
+  const prefixes = [
+    env.HOMEBREW_PREFIX,
+    "/opt/homebrew",
+    "/usr/local",
+    "/home/linuxbrew/.linuxbrew",
+  ];
+  for (const prefix of prefixes) {
+    const normalized = normalizePathRoot(prefix);
+    if (normalized) {
+      roots.push(`${normalized}/Cellar`);
+    }
+  }
+
+  return [...new Set(roots)];
+}
+
+function isKnownPnpmGlobalStore(
+  path: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return pnpmGlobalStoreRoots(env).some((root) => {
+    if (!isPathInsideRoot(path, root)) {
+      return false;
+    }
+
+    const relative = path.slice(root.length).replace(/^\/+/, "");
+    return /^\d+\/\.pnpm\//.test(relative);
+  });
+}
+
+function pnpmGlobalStoreRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots: string[] = [];
+  const home = normalizePathRoot(env.HOME ?? env.USERPROFILE);
+  if (home) {
+    roots.push(`${home}/Library/pnpm/global`);
+    roots.push(`${home}/.local/share/pnpm/global`);
+    roots.push(`${home}/AppData/Local/pnpm/global`);
+  }
+
+  const localAppData = normalizePathRoot(env.LOCALAPPDATA);
+  if (localAppData) {
+    roots.push(`${localAppData}/pnpm/global`);
+  }
+
+  return [...new Set(roots)];
 }
 
 function isKnownNpmGlobalInstall(

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -253,16 +253,15 @@ function npmGlobalNodeModulesRoots(env: NodeJS.ProcessEnv): string[] {
     "/opt/homebrew/lib/node_modules",
     "/opt/local/lib/node_modules",
   ];
-  const prefixes = [
-    env.npm_config_prefix,
-    env.NPM_CONFIG_PREFIX,
-    env.PREFIX,
-  ];
+  const prefixes = [env.npm_config_prefix, env.NPM_CONFIG_PREFIX];
 
   for (const prefix of prefixes) {
     const normalized = normalizePathRoot(prefix);
     if (normalized) {
-      roots.push(`${normalized}/lib/node_modules`, `${normalized}/node_modules`);
+      roots.push(
+        `${normalized}/lib/node_modules`,
+        `${normalized}/node_modules`,
+      );
     }
   }
 
@@ -441,6 +440,8 @@ function notPublishedError(packageName: string): AxiError {
   );
 }
 
+class RegistryNotFoundError extends Error {}
+
 export interface FetchLatestOptions {
   fetchImpl?: FetchLike | null;
   npmView?: (packageName: string) => Promise<string | null>;
@@ -487,7 +488,7 @@ async function fetchRegistryVersion(
         return data.version;
       }
     } else if (response.status === 404) {
-      throw notPublishedError(packageName);
+      throw new RegistryNotFoundError();
     }
 
     return null;
@@ -507,6 +508,7 @@ export async function fetchLatestVersion(
     options.fetchImpl === undefined
       ? (globalThis.fetch as unknown as FetchLike | undefined)
       : (options.fetchImpl ?? undefined);
+  let registryNotFound = false;
 
   if (typeof fetchImpl === "function") {
     try {
@@ -519,7 +521,9 @@ export async function fetchLatestVersion(
         return version;
       }
     } catch (error) {
-      if (error instanceof AxiError) {
+      if (error instanceof RegistryNotFoundError) {
+        registryNotFound = true;
+      } else if (error instanceof AxiError) {
         throw error;
       }
       // Network/parse failure: fall through to the npm CLI fallback.
@@ -527,10 +531,15 @@ export async function fetchLatestVersion(
   }
 
   const viewed = await (
-    options.npmView ?? ((name: string) => npmViewVersion(name, options.platform))
+    options.npmView ??
+    ((name: string) => npmViewVersion(name, options.platform))
   )(packageName);
   if (viewed) {
     return viewed;
+  }
+
+  if (registryNotFound) {
+    throw notPublishedError(packageName);
   }
 
   throw new AxiError(
@@ -566,10 +575,14 @@ async function defaultRunInstall(
 
   return new Promise<InstallResult>((resolve) => {
     const [command, ...args] = argv;
-    const child = spawn(packageManagerExecutable(command, context.platform), args, {
-      stdio: ["ignore", "pipe", "pipe"],
-      shell: shouldUseWindowsPackageManagerShell(command, context.platform),
-    });
+    const child = spawn(
+      packageManagerExecutable(command, context.platform),
+      args,
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+        shell: shouldUseWindowsPackageManagerShell(command, context.platform),
+      },
+    );
     child.stdout?.on("data", (chunk: string | Buffer) => {
       process.stderr.write(chunk);
     });
@@ -605,6 +618,47 @@ function resolveEntry(
   } catch {
     return invokedAs;
   }
+}
+
+function resolveInstalledVersion(
+  invokedAs: string | undefined,
+  realpath: (path: string) => string,
+  fs: IdentityFs,
+): string | undefined {
+  const installedEntry = resolveEntry(invokedAs, realpath);
+  return installedEntry
+    ? readNearestPackageJson(installedEntry, fs).version
+    : undefined;
+}
+
+function homebrewUpgradeOutput(options: {
+  packageName: string;
+  current: string;
+  latest: string;
+  installedVersion: string | undefined;
+  command: string;
+}): AxiRenderable {
+  const update: Record<string, unknown> = {
+    package: options.packageName,
+    previous: options.current,
+    latest: options.latest,
+  };
+
+  if (options.installedVersion) {
+    update.installed = options.installedVersion;
+    update.available = isUpdateAvailable(
+      options.installedVersion,
+      options.latest,
+    );
+  } else {
+    update.action = "upgrade-command-ran";
+    update.result = "installed version unknown";
+  }
+
+  return {
+    update,
+    command: options.command,
+  };
 }
 
 export interface RunUpdateOptions {
@@ -666,10 +720,9 @@ export async function runUpdate(
   const platform = options.platform ?? process.platform;
   const realpath = options.realpath ?? ((path: string) => realpathSync(path));
   const entry = resolveEntry(invokedAs, realpath);
+  const fs = options.fs ?? nodeFs;
 
-  const fromPackageJson = entry
-    ? readNearestPackageJson(entry, options.fs ?? nodeFs)
-    : {};
+  const fromPackageJson = entry ? readNearestPackageJson(entry, fs) : {};
   const packageName = options.packageName ?? fromPackageJson.packageName;
   const current = options.version ?? fromPackageJson.version;
 
@@ -748,6 +801,16 @@ export async function runUpdate(
       `Run \`${plan.command}\` manually`,
       ...(result.message ? [result.message] : []),
     ]);
+  }
+
+  if (method.kind === "homebrew") {
+    return homebrewUpgradeOutput({
+      packageName,
+      current,
+      latest,
+      installedVersion: resolveInstalledVersion(invokedAs, realpath, fs),
+      command: plan.command,
+    });
   }
 
   return {

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -204,15 +204,8 @@ export function detectInstallMethod(options: {
     return { kind: "homebrew", formula: cellar[1] };
   }
 
-  // pnpm global store (virtual store + global root, or PNPM_HOME).
-  const pnpmHome = env.PNPM_HOME?.replaceAll("\\", "/");
-  if (
-    path.includes("/pnpm/global/") ||
-    path.includes("/pnpm-global/") ||
-    path.includes("/.pnpm/") ||
-    /\/Library\/pnpm\//.test(path) ||
-    (pnpmHome && pnpmHome.length > 0 && path.startsWith(pnpmHome))
-  ) {
+  const pnpmHome = normalizePathRoot(env.PNPM_HOME);
+  if (isPathInsideRoot(path, pnpmHome) || isKnownPnpmGlobalStore(path)) {
     return { kind: "pnpm-global" };
   }
 
@@ -222,6 +215,23 @@ export function detectInstallMethod(options: {
   }
 
   return { kind: "unknown" };
+}
+
+function normalizePathRoot(path: string | undefined): string | undefined {
+  const normalized = path?.replaceAll("\\", "/").replace(/\/+$/, "");
+  return normalized && normalized.length > 0 ? normalized : undefined;
+}
+
+function isPathInsideRoot(path: string, root: string | undefined): boolean {
+  return root !== undefined && (path === root || path.startsWith(`${root}/`));
+}
+
+function isKnownPnpmGlobalStore(path: string): boolean {
+  return (
+    /\/Library\/pnpm\/global\/\d+\/\.pnpm\//.test(path) ||
+    /\/\.local\/share\/pnpm\/global\/\d+\/\.pnpm\//.test(path) ||
+    /\/AppData\/Local\/pnpm\/global\/\d+\/\.pnpm\//.test(path)
+  );
 }
 
 export interface UpgradePlan {
@@ -385,12 +395,20 @@ async function defaultRunInstall(
     return { ok: false, message: "No runnable upgrade command" };
   }
 
-  // Announce the command, then stream the installer's output straight through.
   stdout.write(`running: ${plan.command}\n`);
 
   return new Promise<InstallResult>((resolve) => {
     const [command, ...args] = argv;
-    const child = spawn(command, args, { stdio: "inherit", shell: false });
+    const child = spawn(command, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+    });
+    child.stdout?.on("data", (chunk: string | Buffer) => {
+      process.stderr.write(chunk);
+    });
+    child.stderr?.on("data", (chunk: string | Buffer) => {
+      process.stderr.write(chunk);
+    });
     child.on("error", (error) => {
       resolve({ ok: false, message: error.message });
     });
@@ -443,8 +461,26 @@ export interface RunUpdateOptions {
   ) => Promise<InstallResult>;
 }
 
-function isCheckOnly(args: string[]): boolean {
-  return args.includes("--check") || args.includes("--dry-run");
+type UpdateMode = "check" | "install";
+
+function parseUpdateArgs(args: string[], binName: string): UpdateMode {
+  if (args.length === 0) {
+    return "install";
+  }
+
+  if (args.length === 1 && (args[0] === "--check" || args[0] === "--dry-run")) {
+    return "check";
+  }
+
+  const unknown = args.find((arg) => arg !== "--check" && arg !== "--dry-run");
+  throw new AxiError(
+    unknown ? `Unknown update option: ${unknown}` : "Invalid update arguments",
+    "VALIDATION_ERROR",
+    [
+      `Run \`${binName} update --help\``,
+      `Use \`${binName} update --check\` to check without installing`,
+    ],
+  );
 }
 
 /**
@@ -455,9 +491,9 @@ function isCheckOnly(args: string[]): boolean {
 export async function runUpdate(
   options: RunUpdateOptions,
 ): Promise<AxiRenderable> {
-  const checkOnly = isCheckOnly(options.args);
   const invokedAs = options.invokedAs ?? process.argv[1];
   const binName = binNameFromArgv(invokedAs);
+  const mode = parseUpdateArgs(options.args, binName);
   const realpath = options.realpath ?? ((path: string) => realpathSync(path));
   const entry = resolveEntry(invokedAs, realpath);
 
@@ -494,7 +530,7 @@ export async function runUpdate(
   const latest = await fetchLatest(packageName);
   const available = isUpdateAvailable(current, latest);
 
-  if (checkOnly) {
+  if (mode === "check") {
     const output: AxiRenderable = {
       update: { package: packageName, current, latest, available },
     };

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -9,6 +9,7 @@ import type { AxiRenderable } from "./output.js";
 const execFileAsync = promisify(execFile);
 
 const REGISTRY_BASE = "https://registry.npmjs.org";
+const REGISTRY_FETCH_TIMEOUT_MS = 20_000;
 
 /**
  * Minimal `fetch`-like shape so registry lookups stay decoupled from the global
@@ -16,7 +17,7 @@ const REGISTRY_BASE = "https://registry.npmjs.org";
  */
 export type FetchLike = (
   input: string,
-  init?: { headers?: Record<string, string> },
+  init?: { headers?: Record<string, string>; signal?: AbortSignal },
 ) => Promise<{
   ok: boolean;
   status: number;
@@ -378,12 +379,42 @@ export function planUpgrade(
   }
 }
 
-async function npmViewVersion(packageName: string): Promise<string | null> {
+function packageManagerExecutable(
+  command: string,
+  platform: NodeJS.Platform,
+): string {
+  if (
+    platform === "win32" &&
+    (command === "npm" || command === "pnpm" || command === "npx")
+  ) {
+    return `${command}.cmd`;
+  }
+  return command;
+}
+
+function shouldUseWindowsPackageManagerShell(
+  command: string,
+  platform: NodeJS.Platform,
+): boolean {
+  return (
+    platform === "win32" &&
+    (command === "npm" || command === "pnpm" || command === "npx")
+  );
+}
+
+async function npmViewVersion(
+  packageName: string,
+  platform: NodeJS.Platform = process.platform,
+): Promise<string | null> {
   try {
+    const command = packageManagerExecutable("npm", platform);
     const { stdout } = await execFileAsync(
-      "npm",
+      command,
       ["view", packageName, "version"],
-      { timeout: 20_000 },
+      {
+        timeout: 20_000,
+        shell: shouldUseWindowsPackageManagerShell("npm", platform),
+      },
     );
     const version = stdout.trim();
     return version.length > 0 ? version : null;
@@ -413,6 +444,54 @@ function notPublishedError(packageName: string): AxiError {
 export interface FetchLatestOptions {
   fetchImpl?: FetchLike | null;
   npmView?: (packageName: string) => Promise<string | null>;
+  fetchTimeoutMs?: number;
+  platform?: NodeJS.Platform;
+}
+
+async function withRegistryTimeout<T>(
+  timeoutMs: number,
+  operation: (signal: AbortSignal) => Promise<T>,
+): Promise<T> {
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`Registry fetch timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    timer.unref?.();
+  });
+
+  try {
+    return await Promise.race([operation(controller.signal), timeout]);
+  } finally {
+    if (timer) {
+      clearTimeout(timer);
+    }
+  }
+}
+
+async function fetchRegistryVersion(
+  fetchImpl: FetchLike,
+  packageName: string,
+  timeoutMs: number,
+): Promise<string | null> {
+  return withRegistryTimeout(timeoutMs, async (signal) => {
+    const response = await fetchImpl(
+      `${REGISTRY_BASE}/${registryPath(packageName)}/latest`,
+      { headers: { accept: "application/json" }, signal },
+    );
+    if (response.ok) {
+      const data = (await response.json()) as { version?: unknown };
+      if (typeof data.version === "string" && data.version.length > 0) {
+        return data.version;
+      }
+    } else if (response.status === 404) {
+      throw notPublishedError(packageName);
+    }
+
+    return null;
+  });
 }
 
 /**
@@ -431,17 +510,13 @@ export async function fetchLatestVersion(
 
   if (typeof fetchImpl === "function") {
     try {
-      const response = await fetchImpl(
-        `${REGISTRY_BASE}/${registryPath(packageName)}/latest`,
-        { headers: { accept: "application/json" } },
+      const version = await fetchRegistryVersion(
+        fetchImpl,
+        packageName,
+        options.fetchTimeoutMs ?? REGISTRY_FETCH_TIMEOUT_MS,
       );
-      if (response.ok) {
-        const data = (await response.json()) as { version?: unknown };
-        if (typeof data.version === "string" && data.version.length > 0) {
-          return data.version;
-        }
-      } else if (response.status === 404) {
-        throw notPublishedError(packageName);
+      if (version) {
+        return version;
       }
     } catch (error) {
       if (error instanceof AxiError) {
@@ -451,7 +526,9 @@ export async function fetchLatestVersion(
     }
   }
 
-  const viewed = await (options.npmView ?? npmViewVersion)(packageName);
+  const viewed = await (
+    options.npmView ?? ((name: string) => npmViewVersion(name, options.platform))
+  )(packageName);
   if (viewed) {
     return viewed;
   }
@@ -471,9 +548,14 @@ export interface InstallResult {
   message?: string;
 }
 
+export interface RunInstallContext {
+  platform: NodeJS.Platform;
+}
+
 async function defaultRunInstall(
   plan: UpgradePlan,
   stdout: { write: (chunk: string) => unknown },
+  context: RunInstallContext,
 ): Promise<InstallResult> {
   const argv = plan.argv;
   if (!argv || argv.length === 0) {
@@ -484,9 +566,9 @@ async function defaultRunInstall(
 
   return new Promise<InstallResult>((resolve) => {
     const [command, ...args] = argv;
-    const child = spawn(command, args, {
+    const child = spawn(packageManagerExecutable(command, context.platform), args, {
       stdio: ["ignore", "pipe", "pipe"],
-      shell: false,
+      shell: shouldUseWindowsPackageManagerShell(command, context.platform),
     });
     child.stdout?.on("data", (chunk: string | Buffer) => {
       process.stderr.write(chunk);
@@ -543,7 +625,9 @@ export interface RunUpdateOptions {
   runInstall?: (
     plan: UpgradePlan,
     stdout: { write: (chunk: string) => unknown },
+    context: RunInstallContext,
   ) => Promise<InstallResult>;
+  platform?: NodeJS.Platform;
 }
 
 type UpdateMode = "check" | "install";
@@ -579,6 +663,7 @@ export async function runUpdate(
   const invokedAs = options.invokedAs ?? process.argv[1];
   const binName = binNameFromArgv(invokedAs);
   const mode = parseUpdateArgs(options.args, binName);
+  const platform = options.platform ?? process.platform;
   const realpath = options.realpath ?? ((path: string) => realpathSync(path));
   const entry = resolveEntry(invokedAs, realpath);
 
@@ -611,7 +696,8 @@ export async function runUpdate(
   }
 
   const fetchLatest =
-    options.fetchLatest ?? ((name: string) => fetchLatestVersion(name));
+    options.fetchLatest ??
+    ((name: string) => fetchLatestVersion(name, { platform }));
   const latest = await fetchLatest(packageName);
   const available = isUpdateAvailable(current, latest);
 
@@ -656,7 +742,7 @@ export async function runUpdate(
   }
 
   const runInstall = options.runInstall ?? defaultRunInstall;
-  const result = await runInstall(plan, options.stdout);
+  const result = await runInstall(plan, options.stdout, { platform });
   if (!result.ok) {
     throw new AxiError(`Failed to upgrade ${packageName}`, "UPDATE_ERROR", [
       `Run \`${plan.command}\` manually`,

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -210,7 +210,7 @@ export function detectInstallMethod(options: {
   }
 
   // npm global (also covers npm-installed-under-Homebrew-node).
-  if (path.includes("/lib/node_modules/")) {
+  if (isKnownNpmGlobalInstall(path, env)) {
     return { kind: "npm-global" };
   }
 
@@ -232,6 +232,91 @@ function isKnownPnpmGlobalStore(path: string): boolean {
     /\/\.local\/share\/pnpm\/global\/\d+\/\.pnpm\//.test(path) ||
     /\/AppData\/Local\/pnpm\/global\/\d+\/\.pnpm\//.test(path)
   );
+}
+
+function isKnownNpmGlobalInstall(
+  path: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return (
+    npmGlobalNodeModulesRoots(env).some((root) =>
+      isPathInsideRoot(path, root),
+    ) || isKnownVersionManagerNpmGlobal(path, env)
+  );
+}
+
+function npmGlobalNodeModulesRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots = [
+    "/usr/local/lib/node_modules",
+    "/usr/lib/node_modules",
+    "/opt/homebrew/lib/node_modules",
+    "/opt/local/lib/node_modules",
+  ];
+  const prefixes = [
+    env.npm_config_prefix,
+    env.NPM_CONFIG_PREFIX,
+    env.PREFIX,
+  ];
+
+  for (const prefix of prefixes) {
+    const normalized = normalizePathRoot(prefix);
+    if (normalized) {
+      roots.push(`${normalized}/lib/node_modules`, `${normalized}/node_modules`);
+    }
+  }
+
+  const appData = normalizePathRoot(env.APPDATA);
+  if (appData) {
+    roots.push(`${appData}/npm/node_modules`);
+  }
+
+  const home = normalizePathRoot(env.HOME ?? env.USERPROFILE);
+  if (home) {
+    roots.push(
+      `${home}/.npm-global/lib/node_modules`,
+      `${home}/.npm-packages/lib/node_modules`,
+    );
+  }
+
+  return [...new Set(roots)];
+}
+
+function isKnownVersionManagerNpmGlobal(
+  path: string,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return versionManagerNodeRoots(env).some(
+    (root) =>
+      isPathInsideRoot(path, root) && path.includes("/lib/node_modules/"),
+  );
+}
+
+function versionManagerNodeRoots(env: NodeJS.ProcessEnv): string[] {
+  const roots: string[] = [];
+  const home = normalizePathRoot(env.HOME ?? env.USERPROFILE);
+
+  if (home) {
+    roots.push(
+      `${home}/.nvm/versions/node`,
+      `${home}/.local/share/fnm/node-versions`,
+      `${home}/.asdf/installs/nodejs`,
+      `${home}/.nodenv/versions`,
+      `${home}/.local/share/mise/installs/node`,
+      `${home}/.volta/tools/image/node`,
+    );
+  }
+
+  const nvmDir = normalizePathRoot(env.NVM_DIR);
+  if (nvmDir) {
+    roots.push(`${nvmDir}/versions/node`);
+  }
+
+  const fnmDir = normalizePathRoot(env.FNM_DIR);
+  if (fnmDir) {
+    roots.push(`${fnmDir}/node-versions`);
+  }
+
+  return [...new Set(roots)];
 }
 
 export interface UpgradePlan {

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -396,6 +396,8 @@ describe("runAxiCli", () => {
 
     expect(stdout.write).toHaveBeenCalledWith("top help");
     const combined = stdout.write.mock.calls.map((call) => call[0]).join("");
+    expect(combined).toContain('top help\n"built-in":');
+    expect(combined).not.toContain('top help"built-in":');
     expect(combined).toContain("update");
     expect(combined).toContain("update --check");
   });

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -8,12 +8,27 @@ const { installSessionStartHooks } = vi.hoisted(() => ({
   installSessionStartHooks: vi.fn(),
 }));
 
+const { runUpdate } = vi.hoisted(() => ({
+  runUpdate: vi.fn(async () => ({ update: "mock update output" })),
+}));
+
 vi.mock("../src/hooks.js", async () => {
   const actual =
     await vi.importActual<typeof import("../src/hooks.js")>("../src/hooks.js");
   return {
     ...actual,
     installSessionStartHooks,
+  };
+});
+
+vi.mock("../src/update.js", async () => {
+  const actual =
+    await vi.importActual<typeof import("../src/update.js")>(
+      "../src/update.js",
+    );
+  return {
+    ...actual,
+    runUpdate,
   };
 });
 
@@ -305,6 +320,100 @@ describe("runAxiCli", () => {
     });
 
     expect(installSessionStartHooks).not.toHaveBeenCalled();
+  });
+
+  it("handles the built-in update command via runUpdate", async () => {
+    process.argv = ["node", "gh-axi", "update", "--check"];
+
+    await runAxiCli({
+      description: "Manage GitHub state",
+      version: "1.2.3",
+      packageName: "gh-axi",
+      topLevelHelp: "top help",
+      home,
+      commands: { issue },
+      stdout,
+    });
+
+    expect(runUpdate).toHaveBeenCalledTimes(1);
+    expect(runUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: ["--check"],
+        version: "1.2.3",
+        packageName: "gh-axi",
+      }),
+    );
+    expect(String(stdout.write.mock.calls.at(-1)?.[0])).toContain(
+      "mock update output",
+    );
+  });
+
+  it("defers to a tool's own update command when registered", async () => {
+    process.argv = ["node", "gh-axi", "update"];
+    const update = vi.fn(async () => "tool update output");
+
+    await runAxiCli({
+      description: "Manage GitHub state",
+      topLevelHelp: "top help",
+      home,
+      commands: { issue, update },
+      stdout,
+    });
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(runUpdate).not.toHaveBeenCalled();
+    expect(stdout.write).toHaveBeenCalledWith("tool update output\n");
+  });
+
+  it("shows built-in update help without running the upgrade", async () => {
+    process.argv = ["node", "gh-axi", "update", "--help"];
+
+    await runAxiCli({
+      description: "Manage GitHub state",
+      version: "1.2.3",
+      topLevelHelp: "top help",
+      home,
+      commands: { issue },
+      stdout,
+    });
+
+    expect(runUpdate).not.toHaveBeenCalled();
+    expect(String(stdout.write.mock.calls[0]?.[0])).toContain(
+      "command: update",
+    );
+  });
+
+  it("advertises the built-in update command in bare --help", async () => {
+    process.argv = ["node", "gh-axi", "--help"];
+
+    await runAxiCli({
+      description: "Manage GitHub state",
+      topLevelHelp: "top help",
+      home,
+      commands: { issue },
+      stdout,
+    });
+
+    expect(stdout.write).toHaveBeenCalledWith("top help");
+    const combined = stdout.write.mock.calls.map((call) => call[0]).join("");
+    expect(combined).toContain("update");
+    expect(combined).toContain("update --check");
+  });
+
+  it("does not advertise the built-in update when a tool overrides it", async () => {
+    process.argv = ["node", "gh-axi", "--help"];
+    const update = vi.fn(async () => "tool update output");
+
+    await runAxiCli({
+      description: "Manage GitHub state",
+      topLevelHelp: "top help",
+      home,
+      commands: { issue, update },
+      stdout,
+    });
+
+    expect(stdout.write).toHaveBeenCalledTimes(1);
+    expect(stdout.write).toHaveBeenCalledWith("top help");
   });
 
   it("maps validation errors to exit code 2", async () => {

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from "node:events";
 import { describe, expect, it, vi } from "vitest";
 import { AxiError } from "../src/errors.js";
 import {
@@ -148,6 +149,26 @@ describe("detectInstallMethod", () => {
     ).toEqual({ kind: "pnpm-global" });
   });
 
+  it("does not treat local pnpm virtual stores as global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/repo/node_modules/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("does not treat pnpm-shaped project paths as global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/repo/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
   it("detects pnpm via PNPM_HOME", () => {
     expect(
       detectInstallMethod({
@@ -155,6 +176,15 @@ describe("detectInstallMethod", () => {
         env: { PNPM_HOME: "/custom/pnpm-root" },
       }),
     ).toEqual({ kind: "pnpm-global" });
+  });
+
+  it("requires PNPM_HOME matches to stay inside the configured root", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/custom/pnpm-root-other/store/gh-axi/dist/bin/gh-axi.js",
+        env: { PNPM_HOME: "/custom/pnpm-root" },
+      }),
+    ).toEqual({ kind: "unknown" });
   });
 
   it("detects Homebrew formula from the Cellar segment", () => {
@@ -329,6 +359,23 @@ describe("runUpdate", () => {
     expect(runInstall).not.toHaveBeenCalled();
   });
 
+  it("rejects unknown args before fetching or installing", async () => {
+    const fetchLatest = vi.fn(async () => "1.3.0");
+    const runInstall = vi.fn();
+    const error = await runUpdate({
+      ...baseDeps,
+      args: ["--chek"],
+      stdout,
+      fetchLatest,
+      runInstall,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AxiError);
+    expect((error as AxiError).code).toBe("VALIDATION_ERROR");
+    expect(fetchLatest).not.toHaveBeenCalled();
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
   it("reports up-to-date and skips install", async () => {
     const runInstall = vi.fn();
     const output = await runUpdate({
@@ -429,5 +476,74 @@ describe("runUpdate", () => {
 
     expect(error).toBeInstanceOf(AxiError);
     expect((error as AxiError).message).toContain("package name");
+  });
+});
+
+describe("default install runner", () => {
+  it("forwards installer output to stderr", async () => {
+    vi.resetModules();
+
+    const spawn = vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      queueMicrotask(() => {
+        child.stdout.emit("data", "installer stdout\n");
+        child.stderr.emit("data", Buffer.from("installer stderr\n"));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+    const execFile = vi.fn();
+    vi.doMock("node:child_process", () => ({ execFile, spawn }));
+    const stderrWrite = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+    const stdout = { write: vi.fn(() => true) };
+
+    try {
+      const { runUpdate: runUpdateWithMockedSpawn } =
+        await import("../src/update.js");
+      const output = await runUpdateWithMockedSpawn({
+        args: [],
+        stdout,
+        invokedAs: "/usr/local/bin/gh-axi",
+        realpath: () => "/usr/local/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        fs: fakeFs({
+          "/usr/local/lib/node_modules/gh-axi/package.json": JSON.stringify({
+            name: "gh-axi",
+            version: "1.2.3",
+          }),
+        }),
+        env: {},
+        fetchLatest: async () => "1.3.0",
+      });
+
+      expect(spawn).toHaveBeenCalledWith(
+        "npm",
+        ["install", "-g", "gh-axi@latest"],
+        { stdio: ["ignore", "pipe", "pipe"], shell: false },
+      );
+      expect(stdout.write).toHaveBeenCalledWith(
+        "running: npm install -g gh-axi@latest\n",
+      );
+      expect(stdout.write).not.toHaveBeenCalledWith(
+        expect.stringContaining("installer stdout"),
+      );
+      expect(stderrWrite).toHaveBeenCalledWith("installer stdout\n");
+      expect(stderrWrite).toHaveBeenCalledWith(
+        Buffer.from("installer stderr\n"),
+      );
+      expect(output).toMatchObject({
+        update: "gh-axi upgraded 1.2.3 -> 1.3.0",
+      });
+    } finally {
+      stderrWrite.mockRestore();
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
   });
 });

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -139,6 +139,25 @@ describe("detectInstallMethod", () => {
     ).toEqual({ kind: "npm-global" });
   });
 
+  it("does not treat project lib/node_modules paths as npm global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/Users/me/repo/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("detects npm globals under configured version manager roots", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/.nvm/versions/node/v24.13.1/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: { HOME: "/Users/me" },
+      }),
+    ).toEqual({ kind: "npm-global" });
+  });
+
   it("detects pnpm global installs", () => {
     expect(
       detectInstallMethod({
@@ -426,6 +445,29 @@ describe("runUpdate", () => {
       update: "gh-axi upgraded 1.2.3 -> 1.3.0",
       command: "npm install -g gh-axi@latest",
     });
+  });
+
+  it("does not auto-install from local lib/node_modules project paths", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      realpath: () => "/Users/me/repo/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+      fs: fakeFs({
+        "/Users/me/repo/lib/node_modules/gh-axi/package.json": JSON.stringify({
+          name: "gh-axi",
+          version: "1.2.3",
+        }),
+      }),
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: { action: "manual", run: "npm install -g gh-axi@latest" },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
   });
 
   it("is print-only for npx installs", async () => {

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -172,7 +172,7 @@ describe("detectInstallMethod", () => {
       detectInstallMethod({
         entry:
           "/Users/me/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
-        env: {},
+        env: { HOME: "/Users/me" },
       }),
     ).toEqual({ kind: "pnpm-global" });
   });
@@ -193,6 +193,16 @@ describe("detectInstallMethod", () => {
         entry:
           "/Users/me/repo/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
         env: {},
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
+  it("does not treat user-home pnpm lookalike project paths as global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/repo/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: { HOME: "/Users/me" },
       }),
     ).toEqual({ kind: "unknown" });
   });
@@ -223,6 +233,16 @@ describe("detectInstallMethod", () => {
         env: {},
       }),
     ).toEqual({ kind: "homebrew", formula: "gh-axi" });
+  });
+
+  it("does not treat project Cellar paths as Homebrew installs", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/repo/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: { HOME: "/Users/me" },
+      }),
+    ).toEqual({ kind: "unknown" });
   });
 
   it("detects npx / ephemeral caches", () => {
@@ -574,6 +594,54 @@ describe("runUpdate", () => {
     expect(runInstall).not.toHaveBeenCalled();
   });
 
+  it("does not auto-install from project Cellar paths", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      invokedAs: "/Users/me/repo/bin/gh-axi",
+      realpath: () =>
+        "/Users/me/repo/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+      fs: fakeFs({
+        "/Users/me/repo/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+      }),
+      env: { HOME: "/Users/me" },
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: { action: "manual", run: "npm install -g gh-axi@latest" },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-install from project pnpm global-store lookalikes", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      invokedAs: "/Users/me/repo/bin/gh-axi",
+      realpath: () =>
+        "/Users/me/repo/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+      fs: fakeFs({
+        "/Users/me/repo/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+      }),
+      env: { HOME: "/Users/me" },
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: { action: "manual", run: "npm install -g gh-axi@latest" },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
   it("is print-only for npx installs", async () => {
     const runInstall = vi.fn();
     const output = await runUpdate({
@@ -819,7 +887,7 @@ describe("default install runner", () => {
           "C:/Users/me/AppData/Local/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/package.json":
             JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
         }),
-        env: {},
+        env: { LOCALAPPDATA: "C:/Users/me/AppData/Local" },
         fetchLatest: async () => "1.3.0",
         platform: "win32",
       });

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -1,0 +1,433 @@
+import { describe, expect, it, vi } from "vitest";
+import { AxiError } from "../src/errors.js";
+import {
+  compareSemver,
+  detectInstallMethod,
+  fetchLatestVersion,
+  isUpdateAvailable,
+  parseSemver,
+  planUpgrade,
+  readNearestPackageJson,
+  runUpdate,
+  type IdentityFs,
+  type InstallResult,
+  type UpgradePlan,
+} from "../src/update.js";
+
+describe("parseSemver", () => {
+  it("parses a plain version", () => {
+    expect(parseSemver("1.2.3")).toEqual({
+      major: 1,
+      minor: 2,
+      patch: 3,
+      prerelease: [],
+    });
+  });
+
+  it("parses a leading-v and prerelease", () => {
+    expect(parseSemver("v2.0.0-beta.1")).toEqual({
+      major: 2,
+      minor: 0,
+      patch: 0,
+      prerelease: ["beta", "1"],
+    });
+  });
+
+  it("returns null for invalid versions", () => {
+    expect(parseSemver("not-a-version")).toBeNull();
+    expect(parseSemver("1.2")).toBeNull();
+  });
+});
+
+describe("compareSemver", () => {
+  it("orders major, minor, and patch", () => {
+    expect(compareSemver("1.0.0", "2.0.0")).toBe(-1);
+    expect(compareSemver("1.3.0", "1.2.9")).toBe(1);
+    expect(compareSemver("1.2.3", "1.2.3")).toBe(0);
+    expect(compareSemver("1.2.10", "1.2.9")).toBe(1);
+  });
+
+  it("treats a release as newer than its prerelease", () => {
+    expect(compareSemver("1.0.0", "1.0.0-rc.1")).toBe(1);
+    expect(compareSemver("1.0.0-rc.1", "1.0.0")).toBe(-1);
+  });
+
+  it("orders prerelease identifiers", () => {
+    expect(compareSemver("1.0.0-alpha.1", "1.0.0-alpha.2")).toBe(-1);
+    expect(compareSemver("1.0.0-alpha.2", "1.0.0-alpha.10")).toBe(-1);
+    expect(compareSemver("1.0.0-beta", "1.0.0-alpha")).toBe(1);
+  });
+
+  it("falls back to lexical comparison for unparseable input", () => {
+    expect(compareSemver("abc", "abc")).toBe(0);
+    expect(compareSemver("a", "b")).toBe(-1);
+  });
+});
+
+describe("isUpdateAvailable", () => {
+  it("is true only when latest is strictly newer", () => {
+    expect(isUpdateAvailable("1.2.3", "1.3.0")).toBe(true);
+    expect(isUpdateAvailable("1.3.0", "1.3.0")).toBe(false);
+    expect(isUpdateAvailable("1.3.0", "1.2.9")).toBe(false);
+  });
+});
+
+function fakeFs(files: Record<string, string>): IdentityFs {
+  return {
+    existsSync: (path) => Object.prototype.hasOwnProperty.call(files, path),
+    readFileSync: (path) => {
+      if (!Object.prototype.hasOwnProperty.call(files, path)) {
+        throw new Error(`ENOENT: ${path}`);
+      }
+      return files[path];
+    },
+  };
+}
+
+describe("readNearestPackageJson", () => {
+  it("returns the nearest package.json that declares a name", () => {
+    const fs = fakeFs({
+      "/app/pkg/dist/bin/package.json": JSON.stringify({ private: true }),
+      "/app/pkg/package.json": JSON.stringify({
+        name: "gh-axi",
+        version: "1.2.3",
+      }),
+    });
+
+    expect(
+      readNearestPackageJson("/app/pkg/dist/bin/gh-axi.js", fs),
+    ).toMatchObject({ packageName: "gh-axi", version: "1.2.3" });
+  });
+
+  it("skips malformed package.json while walking up", () => {
+    const fs = fakeFs({
+      "/app/pkg/dist/package.json": "{ not json",
+      "/app/pkg/package.json": JSON.stringify({
+        name: "tasks-axi",
+        version: "0.4.0",
+      }),
+    });
+
+    expect(readNearestPackageJson("/app/pkg/dist/cli.js", fs)).toMatchObject({
+      packageName: "tasks-axi",
+      version: "0.4.0",
+    });
+  });
+
+  it("returns empty identity when no named package.json is found", () => {
+    expect(readNearestPackageJson("/nowhere/cli.js", fakeFs({}))).toEqual({});
+  });
+});
+
+describe("detectInstallMethod", () => {
+  it("detects npm global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/usr/local/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "npm-global" });
+  });
+
+  it("treats npm-under-Homebrew-node as npm global, not brew", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/opt/homebrew/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "npm-global" });
+  });
+
+  it("detects pnpm global installs", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "pnpm-global" });
+  });
+
+  it("detects pnpm via PNPM_HOME", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/custom/pnpm-root/store/gh-axi/dist/bin/gh-axi.js",
+        env: { PNPM_HOME: "/custom/pnpm-root" },
+      }),
+    ).toEqual({ kind: "pnpm-global" });
+  });
+
+  it("detects Homebrew formula from the Cellar segment", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/opt/homebrew/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "homebrew", formula: "gh-axi" });
+  });
+
+  it("detects npx / ephemeral caches", () => {
+    expect(
+      detectInstallMethod({
+        entry:
+          "/Users/me/.npm/_npx/abc123/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "npx" });
+  });
+
+  it("returns unknown for unrecognized paths", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/Users/me/src/gh-axi/dist/bin/gh-axi.js",
+        env: {},
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("planUpgrade", () => {
+  it("plans runnable npm and pnpm upgrades", () => {
+    expect(planUpgrade({ kind: "npm-global" }, "gh-axi")).toMatchObject({
+      command: "npm install -g gh-axi@latest",
+      argv: ["npm", "install", "-g", "gh-axi@latest"],
+    });
+    expect(planUpgrade({ kind: "pnpm-global" }, "gh-axi")).toMatchObject({
+      command: "pnpm add -g gh-axi@latest",
+      argv: ["pnpm", "add", "-g", "gh-axi@latest"],
+    });
+  });
+
+  it("plans a runnable brew upgrade when the formula is known", () => {
+    expect(
+      planUpgrade({ kind: "homebrew", formula: "gh-axi" }, "gh-axi"),
+    ).toMatchObject({
+      command: "brew upgrade gh-axi",
+      argv: ["brew", "upgrade", "gh-axi"],
+    });
+  });
+
+  it("is print-only for brew without a formula, npx, and unknown", () => {
+    expect(
+      planUpgrade({ kind: "homebrew", formula: null }, "gh-axi").argv,
+    ).toBeNull();
+    expect(planUpgrade({ kind: "npx" }, "gh-axi").argv).toBeNull();
+    expect(planUpgrade({ kind: "unknown" }, "gh-axi").argv).toBeNull();
+  });
+});
+
+describe("fetchLatestVersion", () => {
+  it("reads the version from the registry endpoint", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "2.5.0" }),
+    }));
+
+    await expect(fetchLatestVersion("gh-axi", { fetchImpl })).resolves.toBe(
+      "2.5.0",
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/gh-axi/latest",
+      { headers: { accept: "application/json" } },
+    );
+  });
+
+  it("encodes scoped package names", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ version: "1.0.0" }),
+    }));
+
+    await fetchLatestVersion("@scope/tool-axi", { fetchImpl });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@scope%2ftool-axi/latest",
+      { headers: { accept: "application/json" } },
+    );
+  });
+
+  it("falls back to npm view on network failure", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("network down");
+    });
+    const npmView = vi.fn(async () => "3.1.4");
+
+    await expect(
+      fetchLatestVersion("gh-axi", { fetchImpl, npmView }),
+    ).resolves.toBe("3.1.4");
+    expect(npmView).toHaveBeenCalledWith("gh-axi");
+  });
+
+  it("throws a not-published AxiError on 404 without falling back", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    }));
+    const npmView = vi.fn(async () => "9.9.9");
+
+    await expect(
+      fetchLatestVersion("ghost-axi", { fetchImpl, npmView }),
+    ).rejects.toMatchObject({
+      code: "UPDATE_ERROR",
+      message: expect.stringContaining("not published"),
+    });
+    expect(npmView).not.toHaveBeenCalled();
+  });
+
+  it("throws a network AxiError when both paths fail", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("offline");
+    });
+    const npmView = vi.fn(async () => null);
+
+    const error = await fetchLatestVersion("gh-axi", {
+      fetchImpl,
+      npmView,
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AxiError);
+    expect((error as AxiError).code).toBe("UPDATE_ERROR");
+  });
+});
+
+describe("runUpdate", () => {
+  const stdout = { write: vi.fn(() => true) };
+
+  const baseDeps = {
+    invokedAs: "/usr/local/bin/gh-axi",
+    realpath: () => "/usr/local/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+    fs: fakeFs({
+      "/usr/local/lib/node_modules/gh-axi/package.json": JSON.stringify({
+        name: "gh-axi",
+        version: "1.2.3",
+      }),
+    }),
+    env: {},
+  };
+
+  it("reports current vs latest for --check without installing", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: ["--check"],
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: {
+        package: "gh-axi",
+        current: "1.2.3",
+        latest: "1.3.0",
+        available: true,
+      },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("reports up-to-date and skips install", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      version: "1.3.0",
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toEqual({
+      update: "gh-axi is already on the latest version (1.3.0)",
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("prefers options.version over package.json for the current version", async () => {
+    const output = await runUpdate({
+      ...baseDeps,
+      args: ["--check"],
+      version: "2.0.0",
+      stdout,
+      fetchLatest: async () => "2.0.0",
+      runInstall: vi.fn(),
+    });
+
+    expect(output).toMatchObject({
+      update: { current: "2.0.0", available: false },
+    });
+  });
+
+  it("runs the detected install method and reports old -> new", async () => {
+    const runInstall = vi.fn(
+      async (): Promise<InstallResult> => ({ ok: true }),
+    );
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    const plan = runInstall.mock.calls[0]?.[0] as UpgradePlan;
+    expect(plan.command).toBe("npm install -g gh-axi@latest");
+    expect(output).toMatchObject({
+      update: "gh-axi upgraded 1.2.3 -> 1.3.0",
+      command: "npm install -g gh-axi@latest",
+    });
+  });
+
+  it("is print-only for npx installs", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      realpath: () =>
+        "/Users/me/.npm/_npx/abc/node_modules/gh-axi/dist/bin/gh-axi.js",
+      fs: fakeFs({
+        "/Users/me/.npm/_npx/abc/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+      }),
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: { action: "manual", run: "npx -y gh-axi@latest" },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("raises an AxiError when the install command fails", async () => {
+    const error = await runUpdate({
+      ...baseDeps,
+      args: [],
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall: async () => ({ ok: false, message: "exit 1" }),
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AxiError);
+    expect((error as AxiError).code).toBe("UPDATE_ERROR");
+  });
+
+  it("raises an AxiError when the package name cannot be resolved", async () => {
+    const error = await runUpdate({
+      args: ["--check"],
+      stdout,
+      invokedAs: "/nowhere/gh-axi",
+      realpath: () => "/nowhere/gh-axi",
+      fs: fakeFs({}),
+      env: {},
+      fetchLatest: async () => "1.3.0",
+    }).catch((caught: unknown) => caught);
+
+    expect(error).toBeInstanceOf(AxiError);
+    expect((error as AxiError).message).toContain("package name");
+  });
+});

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -279,7 +279,10 @@ describe("fetchLatestVersion", () => {
     );
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://registry.npmjs.org/gh-axi/latest",
-      { headers: { accept: "application/json" } },
+      expect.objectContaining({
+        headers: { accept: "application/json" },
+        signal: expect.any(Object),
+      }),
     );
   });
 
@@ -293,7 +296,10 @@ describe("fetchLatestVersion", () => {
     await fetchLatestVersion("@scope/tool-axi", { fetchImpl });
     expect(fetchImpl).toHaveBeenCalledWith(
       "https://registry.npmjs.org/@scope%2ftool-axi/latest",
-      { headers: { accept: "application/json" } },
+      expect.objectContaining({
+        headers: { accept: "application/json" },
+        signal: expect.any(Object),
+      }),
     );
   });
 
@@ -305,6 +311,56 @@ describe("fetchLatestVersion", () => {
 
     await expect(
       fetchLatestVersion("gh-axi", { fetchImpl, npmView }),
+    ).resolves.toBe("3.1.4");
+    expect(npmView).toHaveBeenCalledWith("gh-axi");
+  });
+
+  it("aborts stalled registry fetches and falls back to npm view", async () => {
+    const fetchImpl = vi.fn(
+      async (_input: string, init?: { signal?: AbortSignal }) =>
+        new Promise<never>((_resolve, reject) => {
+          init?.signal?.addEventListener(
+            "abort",
+            () => reject(new Error("aborted")),
+            { once: true },
+          );
+        }),
+    );
+    const npmView = vi.fn(async () => "3.1.4");
+
+    await expect(
+      fetchLatestVersion("gh-axi", {
+        fetchImpl,
+        npmView,
+        fetchTimeoutMs: 1,
+      }),
+    ).resolves.toBe("3.1.4");
+    expect(npmView).toHaveBeenCalledWith("gh-axi");
+  });
+
+  it("aborts stalled registry response bodies and falls back to npm view", async () => {
+    const fetchImpl = vi.fn(
+      async (_input: string, init?: { signal?: AbortSignal }) => ({
+        ok: true,
+        status: 200,
+        json: async () =>
+          new Promise<never>((_resolve, reject) => {
+            init?.signal?.addEventListener(
+              "abort",
+              () => reject(new Error("aborted")),
+              { once: true },
+            );
+          }),
+      }),
+    );
+    const npmView = vi.fn(async () => "3.1.4");
+
+    await expect(
+      fetchLatestVersion("gh-axi", {
+        fetchImpl,
+        npmView,
+        fetchTimeoutMs: 1,
+      }),
     ).resolves.toBe("3.1.4");
     expect(npmView).toHaveBeenCalledWith("gh-axi");
   });
@@ -584,6 +640,75 @@ describe("default install runner", () => {
       });
     } finally {
       stderrWrite.mockRestore();
+      vi.doUnmock("node:child_process");
+      vi.resetModules();
+    }
+  });
+
+  it("runs Windows package-manager installs through command shims", async () => {
+    vi.resetModules();
+
+    const spawn = vi.fn(() => {
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: EventEmitter;
+        stderr: EventEmitter;
+      };
+      child.stdout = new EventEmitter();
+      child.stderr = new EventEmitter();
+      queueMicrotask(() => {
+        child.emit("close", 0);
+      });
+      return child;
+    });
+    const execFile = vi.fn();
+    vi.doMock("node:child_process", () => ({ execFile, spawn }));
+    const stdout = { write: vi.fn(() => true) };
+
+    try {
+      const { runUpdate: runUpdateWithMockedSpawn } =
+        await import("../src/update.js");
+      await runUpdateWithMockedSpawn({
+        args: [],
+        stdout,
+        invokedAs: "C:/Users/me/AppData/Roaming/npm/gh-axi",
+        realpath: () =>
+          "C:/Users/me/AppData/Roaming/npm/node_modules/gh-axi/dist/bin/gh-axi.js",
+        fs: fakeFs({
+          "C:/Users/me/AppData/Roaming/npm/node_modules/gh-axi/package.json":
+            JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+        }),
+        env: { APPDATA: "C:/Users/me/AppData/Roaming" },
+        fetchLatest: async () => "1.3.0",
+        platform: "win32",
+      });
+      await runUpdateWithMockedSpawn({
+        args: [],
+        stdout,
+        invokedAs: "C:/Users/me/AppData/Local/pnpm/gh-axi",
+        realpath: () =>
+          "C:/Users/me/AppData/Local/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/dist/bin/gh-axi.js",
+        fs: fakeFs({
+          "C:/Users/me/AppData/Local/pnpm/global/5/.pnpm/gh-axi@1.2.3/node_modules/gh-axi/package.json":
+            JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+        }),
+        env: {},
+        fetchLatest: async () => "1.3.0",
+        platform: "win32",
+      });
+
+      expect(spawn).toHaveBeenNthCalledWith(
+        1,
+        "npm.cmd",
+        ["install", "-g", "gh-axi@latest"],
+        { stdio: ["ignore", "pipe", "pipe"], shell: true },
+      );
+      expect(spawn).toHaveBeenNthCalledWith(
+        2,
+        "pnpm.cmd",
+        ["add", "-g", "gh-axi@latest"],
+        { stdio: ["ignore", "pipe", "pipe"], shell: true },
+      );
+    } finally {
       vi.doUnmock("node:child_process");
       vi.resetModules();
     }

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -148,6 +148,15 @@ describe("detectInstallMethod", () => {
     ).toEqual({ kind: "unknown" });
   });
 
+  it("does not trust generic PREFIX as an npm global root", () => {
+    expect(
+      detectInstallMethod({
+        entry: "/Users/me/repo/node_modules/gh-axi/dist/bin/gh-axi.js",
+        env: { PREFIX: "/Users/me/repo" },
+      }),
+    ).toEqual({ kind: "unknown" });
+  });
+
   it("detects npm globals under configured version manager roots", () => {
     expect(
       detectInstallMethod({
@@ -365,7 +374,7 @@ describe("fetchLatestVersion", () => {
     expect(npmView).toHaveBeenCalledWith("gh-axi");
   });
 
-  it("throws a not-published AxiError on 404 without falling back", async () => {
+  it("falls back to npm view on registry 404", async () => {
     const fetchImpl = vi.fn(async () => ({
       ok: false,
       status: 404,
@@ -375,11 +384,25 @@ describe("fetchLatestVersion", () => {
 
     await expect(
       fetchLatestVersion("ghost-axi", { fetchImpl, npmView }),
+    ).resolves.toBe("9.9.9");
+    expect(npmView).toHaveBeenCalledWith("ghost-axi");
+  });
+
+  it("throws a not-published AxiError when registry and npm view miss", async () => {
+    const fetchImpl = vi.fn(async () => ({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    }));
+    const npmView = vi.fn(async () => null);
+
+    await expect(
+      fetchLatestVersion("ghost-axi", { fetchImpl, npmView }),
     ).rejects.toMatchObject({
       code: "UPDATE_ERROR",
       message: expect.stringContaining("not published"),
     });
-    expect(npmView).not.toHaveBeenCalled();
+    expect(npmView).toHaveBeenCalledWith("ghost-axi");
   });
 
   it("throws a network AxiError when both paths fail", async () => {
@@ -508,13 +531,38 @@ describe("runUpdate", () => {
     const output = await runUpdate({
       ...baseDeps,
       args: [],
-      realpath: () => "/Users/me/repo/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+      realpath: () =>
+        "/Users/me/repo/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
       fs: fakeFs({
         "/Users/me/repo/lib/node_modules/gh-axi/package.json": JSON.stringify({
           name: "gh-axi",
           version: "1.2.3",
         }),
       }),
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    expect(output).toMatchObject({
+      update: { action: "manual", run: "npm install -g gh-axi@latest" },
+    });
+    expect(runInstall).not.toHaveBeenCalled();
+  });
+
+  it("does not auto-install local dependencies under generic PREFIX", async () => {
+    const runInstall = vi.fn();
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      realpath: () => "/Users/me/repo/node_modules/gh-axi/dist/bin/gh-axi.js",
+      fs: fakeFs({
+        "/Users/me/repo/node_modules/gh-axi/package.json": JSON.stringify({
+          name: "gh-axi",
+          version: "1.2.3",
+        }),
+      }),
+      env: { PREFIX: "/Users/me/repo" },
       stdout,
       fetchLatest: async () => "1.3.0",
       runInstall,
@@ -559,6 +607,86 @@ describe("runUpdate", () => {
 
     expect(error).toBeInstanceOf(AxiError);
     expect((error as AxiError).code).toBe("UPDATE_ERROR");
+  });
+
+  it("reports the re-resolved Homebrew version after upgrade", async () => {
+    const runInstall = vi.fn(
+      async (): Promise<InstallResult> => ({ ok: true }),
+    );
+    const realpath = vi
+      .fn()
+      .mockReturnValueOnce(
+        "/opt/homebrew/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+      )
+      .mockReturnValueOnce(
+        "/opt/homebrew/Cellar/gh-axi/1.2.4/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+      );
+
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      invokedAs: "/opt/homebrew/bin/gh-axi",
+      realpath,
+      fs: fakeFs({
+        "/opt/homebrew/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+        "/opt/homebrew/Cellar/gh-axi/1.2.4/libexec/lib/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.4" }),
+      }),
+      env: {},
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall,
+    });
+
+    const plan = runInstall.mock.calls[0]?.[0] as UpgradePlan;
+    expect(plan.command).toBe("brew upgrade gh-axi");
+    expect(output).toMatchObject({
+      update: {
+        package: "gh-axi",
+        previous: "1.2.3",
+        installed: "1.2.4",
+        latest: "1.3.0",
+        available: true,
+      },
+      command: "brew upgrade gh-axi",
+    });
+  });
+
+  it("does not claim a Homebrew result version when it cannot re-resolve it", async () => {
+    const output = await runUpdate({
+      ...baseDeps,
+      args: [],
+      invokedAs: "/opt/homebrew/bin/gh-axi",
+      realpath: vi
+        .fn()
+        .mockReturnValueOnce(
+          "/opt/homebrew/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/dist/bin/gh-axi.js",
+        )
+        .mockReturnValueOnce("/opt/homebrew/bin/gh-axi"),
+      fs: fakeFs({
+        "/opt/homebrew/Cellar/gh-axi/1.2.3/libexec/lib/node_modules/gh-axi/package.json":
+          JSON.stringify({ name: "gh-axi", version: "1.2.3" }),
+      }),
+      env: {},
+      stdout,
+      fetchLatest: async () => "1.3.0",
+      runInstall: async () => ({ ok: true }),
+    });
+
+    expect(output).toMatchObject({
+      update: {
+        package: "gh-axi",
+        previous: "1.2.3",
+        latest: "1.3.0",
+        action: "upgrade-command-ran",
+        result: "installed version unknown",
+      },
+      command: "brew upgrade gh-axi",
+    });
+    expect(output).not.toMatchObject({
+      update: { installed: expect.any(String) },
+    });
   });
 
   it("raises an AxiError when the package name cannot be resolved", async () => {


### PR DESCRIPTION
## Intent

Add a built-in `update` self-update command to the axi-sdk-js SDK so every axi tool (gh-axi, lavish-axi, chrome-devtools-axi, tasks-axi, ...) automatically gains `<tool> update` and `<tool> update --check` with ZERO per-tool code changes. Scope is the SDK (packages/axi-sdk-js) ONLY.

Design decisions made:
- `update` is a reserved built-in intercepted in runAxiCli() before the options.commands lookup, handled like the existing --help and -v/--version built-ins. If and only if a tool registers its own `update` in options.commands, the built-in defers to the tool's (never silently shadows it). This deferral is intentional and tested.
- Tool identity is auto-derived (no per-tool wiring): walk up from the realpath-resolved process.argv[1] to the nearest package.json for the npm name+version; options.version is preferred for the version when present. A new OPTIONAL packageName on AxiCliOptions is an explicit escape hatch only - the default path requires no tool change.
- Latest version comes from the npm registry HTTP endpoint (https://registry.npmjs.org/<pkg>/latest), falling back to `npm view <pkg> version`, compared with proper semver (including prerelease ordering). Network/registry/not-found failures surface as structured AxiError (code UPDATE_ERROR), never a raw stack trace.
- Self-update runs the right command for the detected install method: npm global -> `npm install -g <pkg>@latest`; pnpm global -> `pnpm add -g <pkg>@latest`; Homebrew (path under /Cellar/) -> `brew upgrade <formula>`; npx/ephemeral cache -> print-only (npx -y already runs latest); unknown -> print-only recommended command (deliberately does NOT guess-install). The command is announced and child output streamed; success reports old -> new version.
- `update --check` (a/k/a --dry-run) reports current vs latest and whether an update is available without installing; already-latest reports up-to-date and exits 0. All output is structured TOON, terse and token-frugal, matching the existing AXI ergonomic style.
- Discoverability: the built-in is advertised in bare --help via an SDK-owned footer (only when the tool has not overridden update), and `update --help` shows a concise reference. The home view was intentionally NOT touched to avoid per-session token cost.

Implementation: new module src/update.ts (semver compare, identity resolution, registry lookup, install-method detection, upgrade orchestration - all with injectable seams), wired into src/cli.ts, re-exported from src/index.ts. Tests are colocated under test/ and fully mock fetch/registry and child_process - NO real network calls and NO real installs. Docs updated in the SDK README and AGENTS.md. Committed as a feat(axi-sdk-js): so release-please bumps axi-sdk-js (expected 0.1.7 -> 0.1.8, a patch bump because bump-patch-for-minor-pre-major is set for this pre-1.0 package).

## What Changed

- Added an SDK-owned `update` built-in for `runAxiCli()`, including `update --check` / `--dry-run`, concise help output, package identity resolution, and explicit deferral when a tool registers its own `update` command.
- Implemented self-update orchestration across npm global, pnpm global, Homebrew, ephemeral/npx, and unknown installs with structured output, semver comparison, registry lookup fallback, timeouts, Windows-aware execution, and safe print-only paths when auto-installing is not appropriate.
- Updated SDK docs and added focused CLI/update coverage plus an E2E demo harness for the new built-in behavior.

## Risk Assessment

⚠️ Medium: The remaining change is a shared SDK self-update path with network, path-detection, and package-manager side effects, but the reviewed implementation now has structured failures, safer non-runnable fallbacks, and focused regression coverage for the prior issues.

## Testing

The SDK test command passed, the evidence runner produced a CLI transcript showing built-in help, `update --help`, `update --check`, `--dry-run`, print-only manual update behavior, already-latest behavior, and tool-owned `update` deferral; an initial evidence-harness assertion issue was corrected and rerun successfully.

- Evidence: [AXI SDK built-in update E2E transcript](https://github.com/kunchenguid/axi/blob/6468ab22ec540993317008ccc1e2875005e302f7/.no-mistakes/evidence/fm/axi-selfupdate-u8/e2e-transcript.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 3 issues found → auto-fixed (5) ✅</summary>

- 🚨 `packages/axi-sdk-js/src/update.ts:212` - The `/.pnpm/` check treats any pnpm virtual-store path as a global install. A tool run from a local project dependency, such as `repo/node_modules/.pnpm/&lt;pkg&gt;/node_modules/&lt;pkg&gt;/...`, would be misclassified as `pnpm-global` and `update` would run `pnpm add -g ...`, mutating a global install instead of refusing or giving a print-only local recommendation. Restrict this branch to known pnpm global roots and treat local `node_modules/.pnpm` paths as non-runnable.
- 🚨 `packages/axi-sdk-js/src/update.ts:458` - `runUpdate` only checks whether `--check` or `--dry-run` is present and ignores every other argument. A typo like `update --chek` falls through to the mutating update path and can install immediately when an update is available. Validate the update args before fetching or installing, and return a usage `AxiError` for anything other than no args, `--check`, or `--dry-run`.
- ⚠️ `packages/axi-sdk-js/src/update.ts:393` - The installer is spawned with `stdio: &#34;inherit&#34;`, so npm/pnpm/brew stdout is interleaved into the command&#39;s stdout outside the injected writer and outside TOON rendering. That breaks the AXI invariant that stdout is structured output and also makes callers that pass a custom `stdout` unable to capture the full update output. Pipe child stdout/stderr and forward installer logs to stderr, leaving stdout for `running`, final result, and structured errors.

🔧 Fix: Harden update install safety
3 warnings still open:
- ⚠️ `packages/axi-sdk-js/src/cli.ts:83` - The built-in help footer is appended without ensuring `topLevelHelp` ends with a newline. Callers can pass help text without a trailing newline, so bare `--help` can render the new footer as `...helpbuilt-in:` on the same line and make the update hint unreadable. Add a separator before writing `builtinCommandsHelp()`.
- ⚠️ `packages/axi-sdk-js/src/update.ts:358` - A 404 from the hardcoded public registry throws before trying the documented `npm view` fallback. That makes update fail for packages resolved by npm config, such as private or scoped registries, even though `npm view &lt;pkg&gt; version` could succeed. Consider falling back first, then reporting not-published only if npm also cannot resolve it.
- ⚠️ `packages/axi-sdk-js/src/update.ts:213` - The npm-global detector accepts any path containing `/lib/node_modules/`. A local or fixture install under a project path like `&lt;repo&gt;/lib/node_modules/&lt;pkg&gt;/...` would be treated as global and `update` would run `npm install -g`, mutating a global install instead of using the safer manual path. Narrow this to known npm global roots or verify against npm&#39;s global root before auto-installing.

🔧 Fix: Harden update help and install detection
4 warnings still open:
- ⚠️ `packages/axi-sdk-js/src/update.ts:434` - The registry `fetch` has no timeout or abort signal, so a stalled registry connection can hang `update` or `update --check` indefinitely and never reach the `npm view` fallback. Add an `AbortSignal` timeout comparable to the 20s npm fallback timeout and handle it as a structured update failure or fallback.
- ⚠️ `packages/axi-sdk-js/src/update.ts:443` - A public-registry 404 throws before trying the documented `npm view` fallback. Packages resolved through npm config, such as private or scoped registries, can 404 on registry.npmjs.org while `npm view &lt;pkg&gt; version` succeeds, so `update --check` fails instead of checking the configured registry.
- ⚠️ `packages/axi-sdk-js/src/update.ts:487` - The runnable install path spawns bare `npm` or `pnpm` with `shell: false`. On Windows those commands are normally `.cmd` shims, so detected Windows npm/pnpm global installs will fail to self-update despite the SDK advertising Windows support. Use a Windows-aware runner for package-manager commands.
- ⚠️ `packages/axi-sdk-js/src/update.ts:615` - Homebrew installs still compare against the npm registry&#39;s latest version, then report `current -&gt; latest` after `brew upgrade`. If the Homebrew formula lags npm or is already current, a successful brew command can leave the installed version below the reported npm latest. For Homebrew installs, compare against brew formula metadata or re-resolve the installed version before claiming the upgrade.

🔧 Fix: Harden update timeouts and Windows installs
3 warnings still open:
- ⚠️ `packages/axi-sdk-js/src/update.ts:265` - `PREFIX` is treated as a trusted npm global prefix. If an npm script or build shell sets `PREFIX` to the project root, a local dependency under `$PREFIX/node_modules/&lt;pkg&gt;/...` is classified as `npm-global`, so `update` can run `npm install -g &lt;pkg&gt;@latest` instead of taking the safer manual path. Drop the generic `PREFIX` input or verify the path against npm&#39;s actual global root before auto-installing.
- ⚠️ `packages/axi-sdk-js/src/update.ts:490` - A registry 404 throws before trying the `npm view` fallback. Packages resolved through npm config, such as private or scoped registries, can 404 on registry.npmjs.org while `npm view &lt;pkg&gt; version` succeeds, so `update --check` fails instead of checking the configured registry.
- ⚠️ `packages/axi-sdk-js/src/update.ts:753` - Successful installs always report `current -&gt; latest` using the npm registry version. For Homebrew installs, `brew upgrade &lt;formula&gt;` can succeed while the formula still lags npm or is already current, so the command can claim an upgrade to a version that is not installed. For Homebrew, compare against brew metadata or re-resolve the installed version before reporting success.

🔧 Fix: Harden update registry and install reporting
2 warnings still open:
- ⚠️ `packages/axi-sdk-js/src/update.ts:203` - The Homebrew detector accepts any path containing `/Cellar/&lt;formula&gt;/`. A local/project install under a path like `/Users/me/repo/Cellar/gh-axi/...` would be classified as `homebrew`, so `update` can run `brew upgrade gh-axi` instead of taking the safer manual path. Restrict this to known Homebrew Cellar roots or verify `brew --prefix` before auto-running.
- ⚠️ `packages/axi-sdk-js/src/update.ts:232` - The pnpm global-store regexes are not anchored to actual global roots. A project path such as `/Users/me/repo/Library/pnpm/global/5/.pnpm/gh-axi@1.2.3/...` still matches and can auto-run `pnpm add -g`, despite being a local path. Anchor these checks to `PNPM_HOME`, the user home global store, or another verified pnpm global root.

🔧 Fix: Anchor self-update install detection roots
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm --dir packages/axi-sdk-js test -- test/update.test.ts test/cli.test.ts`
- `packages/axi-sdk-js/node_modules/.bin/vite-node .no-mistakes/evidence/fm/axi-selfupdate-u8/run-e2e.mjs`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
