### PR TITLE
docs: fail loud on unknown flags in AXI principle 6

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -120,6 +120,22 @@ help: tasks create --title "..." [--body "..."]
 
 Every operation must be completable with flags alone. If a required value is missing, fail immediately with a clear error — don't prompt for it. Suppress prompts from wrapped tools.
 
+### Fail loud on unrecognized input
+
+Reject unknown flags and arguments — never silently ignore them. A dropped flag is worse than an error: the agent gets plausible-looking output it believes is scoped or filtered, then proceeds confidently on wrong data. This is the same guarantee a CLI already owes for an unknown *command*; extend it to flags.
+
+```
+$ tasks list --stat closed
+error: unknown flag --stat for `list`
+help: valid flags for `list`: --state, --assignee, --limit (--help always allowed)
+```
+
+- **Validate before any dependency call**, with exit code 2 — the same as a missing required flag. Each command declares its own known flags; an unrecognized one is rejected by name and the command's valid flags are listed.
+- **`--help` always passes** — it's the one universal flag. Beyond it, a CLI may standardize its own always-allowed globals (e.g. an `--account` selector); whatever the set, those flags pass on every command and are never reported as unknown.
+- **Renamed or removed flags get a targeted hint**, not the generic list — point at what replaced them (`--status was renamed; use --state instead`) so the agent self-corrects in one step.
+- **Per-subcommand flag sets.** For grouped nouns where one command dispatches to subcommands (a `list` vs a `create` under the same noun), validate against the *subcommand's* flags — they differ, and only the subcommand layer knows which is in play.
+- **Make the error self-correcting in one turn.** The agent's deterministic next move after an unknown-flag error is to run `<command> --help` (e.g. `tasks list --help`) — so fold that lookup into the error: list the valid flags inline, or print the command's concise `--help` block directly beneath it. Per §4 the expensive cost is the follow-up call, and per §10 per-command help is already concise, so inlining it collapses the two-turn correction into one.
+
 ### Output channels
 
 - **stdout**: all structured output the agent consumes — data, errors, suggestions

--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -122,7 +122,7 @@ Every operation must be completable with flags alone. If a required value is mis
 
 ### Fail loud on unrecognized input
 
-Reject unknown flags and arguments — never silently ignore them. A dropped flag is worse than an error: the agent gets plausible-looking output it believes is scoped or filtered, then proceeds confidently on wrong data. This is the same guarantee a CLI already owes for an unknown *command*; extend it to flags.
+Reject unknown flags and arguments — never silently ignore them. A dropped flag is worse than an error: the agent gets plausible-looking output it believes is scoped or filtered, then proceeds confidently on wrong data. This is the same guarantee a CLI already owes for an unknown _command_; extend it to flags.
 
 ```
 $ tasks list --stat closed
@@ -133,7 +133,7 @@ help: valid flags for `list`: --state, --assignee, --limit (--help always allowe
 - **Validate before any dependency call**, with exit code 2 — the same as a missing required flag. Each command declares its own known flags; an unrecognized one is rejected by name and the command's valid flags are listed.
 - **`--help` always passes** — it's the one universal flag. Beyond it, a CLI may standardize its own always-allowed globals (e.g. an `--account` selector); whatever the set, those flags pass on every command and are never reported as unknown.
 - **Renamed or removed flags get a targeted hint**, not the generic list — point at what replaced them (`--status was renamed; use --state instead`) so the agent self-corrects in one step.
-- **Per-subcommand flag sets.** For grouped nouns where one command dispatches to subcommands (a `list` vs a `create` under the same noun), validate against the *subcommand's* flags — they differ, and only the subcommand layer knows which is in play.
+- **Per-subcommand flag sets.** For grouped nouns where one command dispatches to subcommands (a `list` vs a `create` under the same noun), validate against the _subcommand's_ flags — they differ, and only the subcommand layer knows which is in play.
 - **Make the error self-correcting in one turn.** The agent's deterministic next move after an unknown-flag error is to run `<command> --help` (e.g. `tasks list --help`) — so fold that lookup into the error: list the valid flags inline, or print the command's concise `--help` block directly beneath it. Per §4 the expensive cost is the follow-up call, and per §10 per-command help is already concise, so inlining it collapses the two-turn correction into one.
 
 ### Output channels

--- a/README.md
+++ b/README.md
@@ -68,18 +68,18 @@ Use `gh-axi` for GitHub and `chrome-devtools-axi` for browser automation.
 
 These principles define what makes a CLI tool "an AXI":
 
-| #   | Principle                          | Summary                                                                     |
-| --- | ---------------------------------- | --------------------------------------------------------------------------- |
-| 1   | **Token-efficient output**         | Use [TOON](https://toonformat.dev/) format for ~40% token savings over JSON |
-| 2   | **Minimal default schemas**        | 3–4 fields per list item, not 10                                            |
-| 3   | **Content truncation**             | Truncate large text with size hints and `--full` escape hatch               |
-| 4   | **Pre-computed aggregates**        | Include aggregated counts and statuses that eliminate round trips           |
-| 5   | **Definitive empty states**        | Explicit "0 results" rather than ambiguous empty output                     |
+| #   | Principle                          | Summary                                                                                     |
+| --- | ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| 1   | **Token-efficient output**         | Use [TOON](https://toonformat.dev/) format for ~40% token savings over JSON                 |
+| 2   | **Minimal default schemas**        | 3–4 fields per list item, not 10                                                            |
+| 3   | **Content truncation**             | Truncate large text with size hints and `--full` escape hatch                               |
+| 4   | **Pre-computed aggregates**        | Include aggregated counts and statuses that eliminate round trips                           |
+| 5   | **Definitive empty states**        | Explicit "0 results" rather than ambiguous empty output                                     |
 | 6   | **Structured errors & exit codes** | Idempotent mutations, structured errors, no interactive prompts, fail loud on unknown flags |
-| 7   | **Ambient context**                | Install opt-in session integrations first, then offer an on-demand skill    |
-| 8   | **Content first**                  | Running with no arguments shows live data, not help text                    |
-| 9   | **Contextual disclosure**          | Include next-step suggestions after each output                             |
-| 10  | **Consistent way to get help**     | Concise per-subcommand reference when agents need it                        |
+| 7   | **Ambient context**                | Install opt-in session integrations first, then offer an on-demand skill                    |
+| 8   | **Content first**                  | Running with no arguments shows live data, not help text                                    |
+| 9   | **Contextual disclosure**          | Include next-step suggestions after each output                                             |
+| 10  | **Consistent way to get help**     | Concise per-subcommand reference when agents need it                                        |
 
 ## AXI Catalog
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ These principles define what makes a CLI tool "an AXI":
 | 3   | **Content truncation**             | Truncate large text with size hints and `--full` escape hatch               |
 | 4   | **Pre-computed aggregates**        | Include aggregated counts and statuses that eliminate round trips           |
 | 5   | **Definitive empty states**        | Explicit "0 results" rather than ambiguous empty output                     |
-| 6   | **Structured errors & exit codes** | Idempotent mutations, structured errors, no interactive prompts             |
+| 6   | **Structured errors & exit codes** | Idempotent mutations, structured errors, no interactive prompts, fail loud on unknown flags |
 | 7   | **Ambient context**                | Install opt-in session integrations first, then offer an on-demand skill    |
 | 8   | **Content first**                  | Running with no arguments shows live data, not help text                    |
 | 9   | **Contextual disclosure**          | Include next-step suggestions after each output                             |

--- a/docs/index.html
+++ b/docs/index.html
@@ -674,7 +674,8 @@
             </li>
             <li>
               <strong>Structured errors &amp; exit codes</strong> &mdash;
-              Idempotent mutations, structured errors, no interactive prompts
+              Idempotent mutations, structured errors, no interactive prompts,
+              fail loud on unknown flags
             </li>
             <li>
               <strong>Ambient context</strong> &mdash; Install opt-in session
@@ -795,6 +796,10 @@ pull_request:
           written to stdout (not stderr), and commands must never prompt for
           interactive input. Reserve stdout for structured data and stderr for
           debug/log output. Use clean exit codes: 0 for success, 1 for errors.
+          Unknown flags must fail loud (exit 2) rather than be silently
+          ignored &mdash; the same guarantee a CLI already gives for an unknown
+          command &mdash; so an agent that invents a flag learns it did nothing
+          instead of trusting unscoped output.
         </p>
 
         <!-- Discoverability -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -796,10 +796,10 @@ pull_request:
           written to stdout (not stderr), and commands must never prompt for
           interactive input. Reserve stdout for structured data and stderr for
           debug/log output. Use clean exit codes: 0 for success, 1 for errors.
-          Unknown flags must fail loud (exit 2) rather than be silently
-          ignored &mdash; the same guarantee a CLI already gives for an unknown
-          command &mdash; so an agent that invents a flag learns it did nothing
-          instead of trusting unscoped output.
+          Unknown flags must fail loud (exit 2) rather than be silently ignored
+          &mdash; the same guarantee a CLI already gives for an unknown command
+          &mdash; so an agent that invents a flag learns it did nothing instead
+          of trusting unscoped output.
         </p>
 
         <!-- Discoverability -->


### PR DESCRIPTION
## Intent

Add a 'fail loud on unrecognized input' sub-principle to AXI principle 6 (Structured errors & exit codes): unknown flags/arguments must be rejected with a VALIDATION_ERROR (exit 2) rather than silently ignored — the same guarantee AXI already gives for an unknown command — because a silently dropped flag hands an agent plausible-but-wrong output it trusts. Sync the addition across the three places the principles are maintained: the spec (.agents/skills/axi/SKILL.md, section 6), the README principle-summary table, and the docs site (docs/index.html). Use the repo's existing hypothetical 'tasks' CLI as the running example and '--account' as the example global flag (not --json, which isn't an AXI concept). Closes #62. This is a docs/spec-only change — no SDK or other code changes.

## What Changed

- Added a "fail loud on unrecognized input" sub-principle to AXI principle 6 (Structured errors & exit codes): unknown flags/arguments must be rejected with a `VALIDATION_ERROR` (exit 2) rather than silently ignored, extending the existing unknown-command guarantee.
- Synced the addition across the three places principles are maintained — the spec (`.agents/skills/axi/SKILL.md` §6), the README principle-summary table, and the docs site (`docs/index.html`) — using the hypothetical `tasks` CLI and `--account` as the running example.
- Reformatted the touched docs files with prettier.

## Risk Assessment

✅ Low: Documentation/spec-only change that adds a new sub-principle consistently across three synced surfaces, with exit-code semantics matching the existing spec and no code paths affected.

## Testing

No automated tests cover the docs/spec content, so I validated the diff scope, grep-verified every intent-specific detail across the three synced locations (SKILL.md spec subsection, README table, docs site), and rendered docs/index.html in a real browser to capture reviewer-visible screenshots of both the principle-6 summary row and the detail paragraph. All surfaces render the new "fail loud on unknown flags / exit 2" language correctly and consistently; the worktree remains clean with no transient artifacts.

- Evidence: Docs site — 10-principles summary (row 6 updated) (local file: <code>/tmp/no-mistakes-evidence/01KWF9W72J6XYEK8Z57J99T8H9/docs-principle6-summary.png</code>)
- Evidence: Docs site — principle 6 detail paragraph (fail loud, exit 2) (local file: <code>/tmp/no-mistakes-evidence/01KWF9W72J6XYEK8Z57J99T8H9/docs-principle6-detail.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff eddde85..49bdd02` — confirmed only SKILL.md, README.md, docs/index.html changed (docs/spec-only, no SDK/code changes)</code>
- <code>grep-verified intent details in SKILL.md §6: `tasks list --stat closed` example, `--account` global (no `--json`), `exit code 2`, unknown-command framing</code>
- <code>Rendered `docs/index.html` via `chrome-devtools-axi open file://.../docs/index.html` and scrolled to principle 6</code>
- `Screenshot of the 10-principles summary list showing row 6 now reads '...no interactive prompts, fail loud on unknown flags'`
- `Screenshot of the principle-6 detail paragraph showing 'Unknown flags must fail loud (exit 2) rather than be silently ignored...'`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
