### PR TITLE
docs: document axi-sdk-js release flow

### DIFF
--- a/.no-mistakes/evidence/fm/axi-sdk-publish-u4/release-validation.md
+++ b/.no-mistakes/evidence/fm/axi-sdk-publish-u4/release-validation.md
@@ -1,0 +1,166 @@
+# axi-sdk-js release validation
+
+Validated target `7f62da038241362e320d31dfe99433a8acda1172` against base `d6560fca9e6dd8fdd9672bb8fa49e740ca86658f`.
+
+## Scope
+
+The target diff only changes `AGENTS.md`, adding the maintainer runbook for publishing `axi-sdk-js` through release-please.
+
+## Local SDK checks
+
+Command:
+
+```sh
+pnpm --dir packages/axi-sdk-js test
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests  115 passed (115)
+test/update.test.ts (53 tests)
+```
+
+Command:
+
+```sh
+pnpm --dir packages/axi-sdk-js run build
+```
+
+Result:
+
+```text
+$ tsc -p tsconfig.json
+```
+
+The generated `packages/axi-sdk-js/dist` contained `dist/update.js`, `dist/update.d.ts`, `dist/cli.js`, and `dist/index.js`.
+`dist/cli.js` included `RESERVED_COMMANDS = ["update"]` and the built-in `runUpdate` dispatch.
+
+## Built SDK CLI smoke checks
+
+The built SDK was exercised through a minimal `runAxiCli` consumer.
+
+Command shape:
+
+```sh
+node --input-type=module -e 'import { runAxiCli } from "./packages/axi-sdk-js/dist/index.js"; ...'
+```
+
+Top-level help exposed the inherited built-in:
+
+```text
+commands:
+  issue
+"built-in":
+  update: Upgrade `toy-axi` to the latest published version
+  "update --check": Report current vs latest without installing
+```
+
+`toy-axi update --help` rendered the built-in command help:
+
+```text
+command: update
+description: Upgrade `toy-axi` to the latest published npm version
+flags:
+  "--check": Report current vs latest and exit without installing
+examples[2]: toy-axi update,toy-axi update --check
+```
+
+`toy-axi update --check` queried npm without installing:
+
+```text
+update:
+  package: axi-sdk-js
+  current: 0.1.7
+  latest: 0.1.8
+  available: true
+help[1]: Run `toy-axi update` to upgrade
+```
+
+## Public npm state
+
+Command:
+
+```sh
+npm view axi-sdk-js version dist-tags.latest
+```
+
+Result:
+
+```text
+version = '0.1.8'
+dist-tags.latest = '0.1.8'
+```
+
+Command:
+
+```sh
+npm pack --dry-run --json axi-sdk-js@0.1.8
+```
+
+Selected result:
+
+```text
+id: axi-sdk-js@0.1.8
+version: 0.1.8
+files:
+  dist/cli.d.ts
+  dist/cli.js
+  dist/index.d.ts
+  dist/index.js
+  dist/update.d.ts
+  dist/update.js
+```
+
+## GitHub release path state
+
+Command:
+
+```sh
+gh-axi pr view 61 --full
+```
+
+Selected result:
+
+```text
+number: 61
+title: chore(main): release axi-sdk-js 0.1.8
+state: merged
+author: app/github-actions
+merged: 2026-06-27T03:53:49Z
+body includes: This PR was generated with Release Please
+body includes: axi-sdk-js: add built-in self-update command (#60)
+```
+
+Command:
+
+```sh
+gh-axi release view axi-sdk-js-v0.1.8 --full
+```
+
+Selected result:
+
+```text
+tag: axi-sdk-js-v0.1.8
+name: axi-sdk-js: v0.1.8
+author: github-actions[bot]
+body includes: axi-sdk-js: add built-in self-update command (#60)
+```
+
+Command:
+
+```sh
+gh-axi run list --workflow axi-sdk-js-release-please.yml --branch main --limit 5
+```
+
+Selected result:
+
+```text
+title: chore(main): release axi-sdk-js 0.1.8 (#61)
+status: completed
+conclusion: success
+workflow: axi-sdk-js-release-please
+branch: main
+event: push
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,7 +62,7 @@ Requires Node.js >= 20 and `gh` CLI installed and authenticated.
 
 How it works:
 
-1. Land a conventional-commit change on `main` that touches `packages/axi-sdk-js/**` (a `feat:` or `fix:` bumps the version; `feat:` -> minor-equivalent, `fix:` -> patch under the pre-1.0 config in `release-please-config.json`).
+1. Land a conventional-commit change on `main` that touches `packages/axi-sdk-js/**`; under the current pre-1.0 config in `release-please-config.json`, `feat:` and `fix:` commits both bump patch versions (for example `0.1.7` -> `0.1.8`), while breaking changes bump minor versions.
 2. The `axi-sdk-js-release-please` workflow opens or updates a release PR titled `chore(main): release axi-sdk-js <version>`.
    That PR is the only place the version in `packages/axi-sdk-js/package.json`, `packages/axi-sdk-js/CHANGELOG.md`, and `.release-please-manifest.json` may change.
    Never hand-edit those files; the `Guard generated files` check fails any PR that does.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ How it works:
 
 1. Land a conventional-commit change on `main` that touches `packages/axi-sdk-js/**`; under the current pre-1.0 config in `release-please-config.json`, `feat:` and `fix:` commits both bump patch versions (for example `0.1.7` -> `0.1.8`), while breaking changes bump minor versions.
 2. The `axi-sdk-js-release-please` workflow opens or updates a release PR titled `chore(main): release axi-sdk-js <version>`.
-   That PR is the only place the version in `packages/axi-sdk-js/package.json`, `packages/axi-sdk-js/CHANGELOG.md`, and `.release-please-manifest.json` may change.
-   Never hand-edit those files; the `Guard generated files` check fails any PR that does.
+   That PR is the only place the version in `packages/axi-sdk-js/package.json` may change, and the only place `packages/axi-sdk-js/CHANGELOG.md` and `.release-please-manifest.json` may change.
+   Never hand-edit those files; the `Guard generated files` check specifically fails PRs that modify the generated changelog or manifest outside release-please.
 3. **Publishing is a maintainer action: merge the open release-please PR.**
    That merge creates the git tag and GitHub release, after which the same workflow runs `format:check`, `lint`, `build`, `test`, then `npm publish --access public --provenance` (OIDC provenance via `id-token: write`, no static npm token in the repo).
 4. Verify with `npm view axi-sdk-js version` and confirm the published `dist/` carries the new code (for example `npm pack axi-sdk-js@<version>` then grep the extracted `dist/`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,22 @@ Requires Node.js >= 20 and `gh` CLI installed and authenticated.
 
 `bench-browser/src/runner.ts` orchestrates browser benchmark runs: creates a workspace with condition-specific CLAUDE.md, manages browser daemon lifecycle, invokes Claude with `--bare` isolation, parses JSONL usage, and grades results. Conditions are defined in `bench-browser/config/conditions.yaml`, tasks in `bench-browser/config/tasks.yaml`.
 
+## Releasing `axi-sdk-js`
+
+`axi-sdk-js` versions and publishes to npm through [release-please](https://github.com/googleapis/release-please); there is no manual `npm version` or `npm publish` step.
+
+How it works:
+
+1. Land a conventional-commit change on `main` that touches `packages/axi-sdk-js/**` (a `feat:` or `fix:` bumps the version; `feat:` -> minor-equivalent, `fix:` -> patch under the pre-1.0 config in `release-please-config.json`).
+2. The `axi-sdk-js-release-please` workflow opens or updates a release PR titled `chore(main): release axi-sdk-js <version>`.
+   That PR is the only place the version in `packages/axi-sdk-js/package.json`, `packages/axi-sdk-js/CHANGELOG.md`, and `.release-please-manifest.json` may change.
+   Never hand-edit those files; the `Guard generated files` check fails any PR that does.
+3. **Publishing is a maintainer action: merge the open release-please PR.**
+   That merge creates the git tag and GitHub release, after which the same workflow runs `format:check`, `lint`, `build`, `test`, then `npm publish --access public --provenance` (OIDC provenance via `id-token: write`, no static npm token in the repo).
+4. Verify with `npm view axi-sdk-js version` and confirm the published `dist/` carries the new code (for example `npm pack axi-sdk-js@<version>` then grep the extracted `dist/`).
+
+Because the release PR carries the version bump, a downstream `*-axi` tool only needs to bump its `axi-sdk-js` dependency to inherit new SDK built-ins (such as the reserved `update` command) - no code change in the tool.
+
 ## Conventions
 
 - Packages use ES modules (`"type": "module"`) with TypeScript targeting ES2022/Node16.


### PR DESCRIPTION
## Intent

Release the axi-sdk-js package so the self-update 'update' built-in (already in source: RESERVED_COMMANDS, runUpdate, cli dispatch, help entries, update.ts, update.test.ts) reaches npm, letting downstream *-axi tools inherit '<tool> update' by bumping the dep.

Key finding while doing the work: the repo publishes axi-sdk-js exclusively via release-please. The release-triggering commit (d6560fc, feat(axi-sdk-js): add built-in self-update command #60) already landed, and release-please ALREADY opened release PR #61 'chore(main): release axi-sdk-js 0.1.8', which bumps package.json + .release-please-manifest.json to 0.1.8 and adds the CHANGELOG entry for the update built-in. Merging PR #61 is what tags the release and triggers the CI 'npm publish --access public --provenance' step.

Deliberate decision (important for reviewing the diff scope): I did NOT hand-bump the version/CHANGELOG/manifest. CONTRIBUTING.md and the 'Guard generated files' CI check forbid hand-editing those files; release-please's PR is the only place they may change, so manually bumping would both conflict with PR #61 and fail CI. The actual publish is a captain action (merge PR #61; npm auth/OIDC is owned by the maintainer), so the task is to get to one-step-from-published and flag it - which is already true via PR #61.

I verified the release path locally before reporting: pnpm install --frozen-lockfile, build, 115 tests (incl. 53 update tests), lint, and format:check all green; the built dist carries update.js + RESERVED_COMMANDS + runUpdate; and the currently-published 0.1.7 confirmed to lack update.

The only committable change in this branch is therefore documentation: a new 'Releasing axi-sdk-js' maintainer runbook section in AGENTS.md (root; CLAUDE.md is a symlink to it). It captures the previously-undocumented publish flow - conventional commits drive release-please, merging the generated release PR runs npm publish --provenance, and how to verify with npm view / npm pack. This is durable project knowledge that was missing (CONTRIBUTING only covered the contributor-side conventional-commit rule, not how a publish happens or how to verify it). Plain ASCII dashes used intentionally per repo author's style preference (no em dashes).

## What Changed
- Documented the `axi-sdk-js` release-please publish flow in `AGENTS.md`, including the generated release PR, provenance publish step, and npm verification commands.
- Clarified the current pre-1.0 release behavior: `feat:` and `fix:` commits both produce patch bumps, while generated changelog and manifest updates stay in release-please PRs.
- Added branch release validation notes capturing the checked publish path and related verification context.

## Risk Assessment

✅ Low: The HEAD diff is limited to AGENTS.md release-process documentation and its claims match the checked-in release-please config and GitHub workflows, so there is little merge risk.

## Testing

Checked the target diff scope, ran the SDK test suite and build, smoke-tested the built CLI update surfaces, verified npm latest and package contents, verified PR #61, the GitHub release, and the successful release-please workflow run, then removed the transient `packages/axi-sdk-js/dist` build output. An exploratory `gh-axi pr list --fields ...` command used unsupported fields and was replaced by the direct PR, release, and run checks; it was not a product failure.

- Evidence: [Release validation evidence](https://github.com/kunchenguid/axi/blob/074af4b5867ae9de2b4707f5e51dc7c47c4cc052/.no-mistakes/evidence/fm/axi-sdk-publish-u4/release-validation.md)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `AGENTS.md:65` - This says `feat:` maps to a minor-equivalent bump, but the repo sets `bump-patch-for-minor-pre-major: true`, which release-please documents as making `feat` commits bump patch instead of minor for versions below 1.0. Since `axi-sdk-js` is currently 0.1.7, a `feat:` release should be documented as 0.1.8-style patch, not minor. Source: https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md#configfile

🔧 Fix: Clarify release-please pre-1.0 patch bumps
1 warning still open:
- ⚠️ `AGENTS.md:68` - This says the `Guard generated files` check fails any PR that hand-edits all files listed above, including `packages/axi-sdk-js/package.json`, but the workflow only checks `packages/axi-sdk-js/CHANGELOG.md` and `.release-please-manifest.json`. Scope this sentence to the guarded files, or add a dedicated guard for package version bumps, so agents do not assume package.json version edits are CI-blocked when they are not.

🔧 Fix: Clarify generated file guard scope
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-status d6560fca9e6dd8fdd9672bb8fa49e740ca86658f..7f62da038241362e320d31dfe99433a8acda1172`
- `pnpm --dir packages/axi-sdk-js test`
- `pnpm --dir packages/axi-sdk-js run build`
- <code>Built SDK smoke check with `runAxiCli({ argv: [&#34;--help&#34;] })`</code>
- <code>Built SDK smoke check with `runAxiCli({ argv: [&#34;update&#34;, &#34;--help&#34;] })`</code>
- <code>Built SDK smoke check with `runAxiCli({ argv: [&#34;update&#34;, &#34;--check&#34;], packageName: &#34;axi-sdk-js&#34;, version: &#34;0.1.7&#34; })`</code>
- `npm view axi-sdk-js version dist-tags.latest`
- `npm pack --dry-run --json axi-sdk-js@0.1.8`
- `gh-axi pr view 61 --full`
- `gh-axi release view axi-sdk-js-v0.1.8 --full`
- `gh-axi run list --workflow axi-sdk-js-release-please.yml --branch main --limit 5`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
