### PR TITLE
fix(axi-sdk-js): resolve portable hook command from npm wrapper shims

### DIFF
--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -164,6 +164,8 @@ Claude Code and Codex receive native `SessionStart` hooks, while OpenCode receiv
 
 Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
 
+On Windows, npm global bins are wrapper shims (`.cmd` files and extensionless Git Bash scripts) rather than symlinks, so the realpath match never succeeds. The resolver also parses each shim to recover the script it ultimately runs and matches that against the executable, so the plain binary name still works there.
+
 For custom wrappers, pass `binaryNames: ["my-axi"]` to `installSessionStartHooks()`.
 
 ## Development

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -58,6 +58,7 @@ export interface PortableHookCommandContext {
   pathEntries: string[];
   pathExtensions: string[];
   resolveRealPath: (absolutePath: string) => string | undefined;
+  resolveShimTarget?: (shimPath: string) => string | undefined;
 }
 
 function isManagedHook(hook: HookEntry | undefined, marker: string): boolean {
@@ -379,6 +380,14 @@ export function resolvePortableHookCommand(
         if (resolvedCandidate && resolvedCandidate === resolvedExec) {
           return name;
         }
+
+        // npm global bins on Windows are wrapper shims, not symlinks, so the
+        // realpath check above never matches. Parse the shim to recover the
+        // script it ultimately runs and compare that instead.
+        const shimTarget = context.resolveShimTarget?.(candidate);
+        if (shimTarget && shimTarget === resolvedExec) {
+          return name;
+        }
       }
     }
   }
@@ -386,12 +395,30 @@ export function resolvePortableHookCommand(
   return execPath;
 }
 
+const NPM_SHIM_SCRIPT_PATTERNS = [
+  // Git Bash / POSIX shim: exec node "$basedir/node_modules/<pkg>/.../cli.js"
+  /"\$basedir\/([^"]+\.[cm]?js)"/,
+  // Windows .cmd shim: "%dp0%\node_modules\<pkg>\...\cli.js"
+  /%~?dp0%?[\\/]([^"\r\n]+\.[cm]?js)/i,
+];
+
+export function extractNpmShimScriptPath(content: string): string | undefined {
+  for (const pattern of NPM_SHIM_SCRIPT_PATTERNS) {
+    const match = content.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
 function buildDefaultPortableCommandContext(): PortableHookCommandContext {
   const rawPath = process.env.PATH ?? process.env.Path ?? "";
   const pathEntries = rawPath.split(delimiter).filter(Boolean);
   const pathExtensions =
     process.platform === "win32"
-      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+      ? // Git Bash resolves the extensionless shim, which PATHEXT omits.
+        ["", ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")]
       : [""];
   return {
     pathEntries,
@@ -403,6 +430,19 @@ function buildDefaultPortableCommandContext(): PortableHookCommandContext {
           return undefined;
         }
         return realpathSync(absolutePath);
+      } catch {
+        return undefined;
+      }
+    },
+    resolveShimTarget: (shimPath) => {
+      try {
+        const relative = extractNpmShimScriptPath(
+          readFileSync(shimPath, "utf-8"),
+        );
+        if (!relative) {
+          return undefined;
+        }
+        return realpathSync(resolve(dirname(shimPath), relative));
       } catch {
         return undefined;
       }

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   computeCodexConfigUpdate,
   computeSessionStartHookUpdate,
+  extractNpmShimScriptPath,
   installSessionStartHooks,
   resolvePortableHookCommand,
   shouldInstallHooksForNodeAxiExecPath,
@@ -304,6 +305,75 @@ describe("resolvePortableHookCommand", () => {
     const context = makeContext({ [exec]: exec });
     expect(resolvePortableHookCommand(exec, [], "gh-axi", context)).toBe(exec);
   });
+
+  it("returns the plain binary name when a shim wrapper targets the exec file", () => {
+    const exec = "/npm/node_modules/gh-axi/dist/bin/gh-axi.js";
+    const shim = join("/npm", "gh-axi");
+    const context = {
+      pathEntries: ["/npm"],
+      pathExtensions: ["", ".CMD"],
+      // npm shims are wrappers, so realpath equals the shim itself, never exec.
+      resolveRealPath: (p: string) => ({ [exec]: exec, [shim]: shim })[p],
+      resolveShimTarget: (p: string) => (p === shim ? exec : undefined),
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe("gh-axi");
+  });
+
+  it("ignores a shim wrapper that targets a different install", () => {
+    const exec = "/src/gh-axi/dist/bin/gh-axi.js";
+    const shim = join("/npm", "gh-axi");
+    const context = {
+      pathEntries: ["/npm"],
+      pathExtensions: ["", ".CMD"],
+      resolveRealPath: (p: string) => ({ [exec]: exec, [shim]: shim })[p],
+      resolveShimTarget: (p: string) =>
+        p === shim ? "/other/gh-axi.js" : undefined,
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe(exec);
+  });
+});
+
+describe("extractNpmShimScriptPath", () => {
+  it("reads the script reference from a Git Bash shim", () => {
+    const shim = [
+      "#!/bin/sh",
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      'if [ -x "$basedir/node" ]; then',
+      '  exec "$basedir/node"  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      "else",
+      '  exec node  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      "fi",
+    ].join("\n");
+
+    expect(extractNpmShimScriptPath(shim)).toBe(
+      "node_modules/gh-axi/dist/bin/gh-axi.js",
+    );
+  });
+
+  it("reads the script reference from a Windows .cmd shim", () => {
+    const shim = [
+      "@ECHO off",
+      "SETLOCAL",
+      "SET dp0=%~dp0",
+      '"%_prog%"  "%dp0%\\node_modules\\gh-axi\\dist\\bin\\gh-axi.js" %*',
+    ].join("\r\n");
+
+    expect(extractNpmShimScriptPath(shim)).toBe(
+      "node_modules\\gh-axi\\dist\\bin\\gh-axi.js",
+    );
+  });
+
+  it("returns undefined when no script reference is present", () => {
+    expect(extractNpmShimScriptPath("#!/bin/sh\nexec node --version\n")).toBe(
+      undefined,
+    );
+  });
 });
 
 describe("shouldInstallHooksForNodeAxiExecPath", () => {
@@ -412,6 +482,43 @@ describe("installSessionStartHooks (portable command)", () => {
     const execFile = join(pkgBin, "gh-axi.js");
     writeFileSync(execFile, "// stub\n", "utf-8");
     symlinkSync(execFile, join(pathDir, "gh-axi"));
+
+    process.env.PATH = pathDir;
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      binaryNames: ["gh-axi"],
+      homeDir: home,
+    });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+  });
+
+  it("writes the plain binary name when a PATH npm wrapper shim targets the exec file", () => {
+    const home = join(tmp, "home");
+    const pathDir = join(tmp, "path-bin");
+    const pkgBin = join(pathDir, "node_modules", "gh-axi", "dist", "bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+
+    // npm installs an extensionless wrapper shim on PATH (not a symlink); Git
+    // Bash runs it and it execs the .js relative to its own directory.
+    writeFileSync(
+      join(pathDir, "gh-axi"),
+      [
+        "#!/bin/sh",
+        'basedir=$(dirname "$0")',
+        '  exec node  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      ].join("\n"),
+      "utf-8",
+    );
 
     process.env.PATH = pathDir;
 


### PR DESCRIPTION
## What Changed

- `resolvePortableHookCommand` now parses npm wrapper shims (Git Bash/POSIX `exec node "$basedir/.../cli.js"` and Windows `.cmd` `%dp0%\...\cli.js`) via a new `resolveShimTarget` hook and `extractNpmShimScriptPath` helper, so a PATH entry matches the executable on Windows where global bins are shims rather than symlinks — restoring the portable `gh-axi` command instead of writing an absolute path.
- The default Windows command context now includes the extensionless candidate ahead of `PATHEXT`, matching how Git Bash resolves the shim.
- Added `hooks.test.ts` coverage for shim matching and shim-script extraction, plus a README note documenting the Windows npm shim resolution.

## Risk Assessment

✅ Low: 變更範圍小且自我封閉,僅為 Windows shim 解析新增一條 realpath 比對的後備路徑,有完整單元與端對端測試覆蓋,且對非 Windows 行為無回歸。

## Testing

執行 axi-sdk-js 的 hooks 單元／整合測試（37 tests 全綠，涵蓋本次新增的 shim 解析路徑），並以真實檔案系統重現 Windows npm wrapper-shim 佈局做端到端驗證：修復後 SessionStart hook 寫入的是可攜的 gh-axi，而對照組（修復前的 base 版 hooks.ts）在同一佈局下退回機器專屬的絕對 exec 路徑，直接證明使用者面向的行為改善。此為 Node SDK／CLI 行為變更，無 UI 表面，因此以實際產生的 settings.json hook 指令字串作為產品層級證據；前後對照已存成證據檔。整體結果通過，無失敗或環境問題。

<details>
<summary>Evidence: Windows npm shim hook 解析前後對照（base 退回絕對路徑 vs fixed 用 gh-axi）</summary>

<code>BASE: 寫入的 hook 指令 = &#34;/.../node_modules/gh-axi/dist/bin/gh-axi.js&#34;（脆弱絕對路徑）&#10;TARGET: 寫入的 hook 指令 = &#34;gh-axi&#34;（可攜，跨機器有效）</code>

```text
=== Windows npm wrapper-shim hook resolution: 前後對照 ===

--- BASE (743619a, 修復前) ---
[Windows npm shim layout] PATH 上的 npm wrapper shim 指向 exec
  exec 絕對路徑 : /tmp/axi-shim-nEfLlj/npm-global/node_modules/gh-axi/dist/bin/gh-axi.js
  寫入的 hook 指令 : "/tmp/axi-shim-nEfLlj/npm-global/node_modules/gh-axi/dist/bin/gh-axi.js"
  結果: 退回脆弱的絕對路徑（換機器即失效）

--- TARGET (c5f2c6d, 修復後) ---
[Windows npm shim layout] PATH 上的 npm wrapper shim 指向 exec
  exec 絕對路徑 : /tmp/axi-shim-savZbh/npm-global/node_modules/gh-axi/dist/bin/gh-axi.js
  寫入的 hook 指令 : "gh-axi"
  結果: 可攜的 gh-axi（跨機器有效）
```
</details>
<details>
<summary>Evidence: 端到端重現腳本（真實檔案系統模擬 npm wrapper shim + 實際 installSessionStartHooks）</summary>

```text
// 重現 Windows npm 全域 bin 為 wrapper shim（非 symlink）的情境，
// 驗證 SessionStart hook 寫入的是可攜的 gh-axi 而非絕對 exec 路徑。
import { mkdirSync, mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
import { join } from "node:path";
import { tmpdir } from "node:os";
import { installSessionStartHooks } from "/home/nickyu/.no-mistakes/worktrees/ef470049f539/01KWBVNED1V3H5XP6ZDST0TQ1Z/packages/axi-sdk-js/dist/index.js";

function run(label) {
  const root = mkdtempSync(join(tmpdir(), "axi-shim-"));
  const home = join(root, "home");
  const pathDir = join(root, "npm-global");
  const pkgBin = join(pathDir, "node_modules", "gh-axi", "dist", "bin");
  mkdirSync(home, { recursive: true });
  mkdirSync(pkgBin, { recursive: true });

  const execFile = join(pkgBin, "gh-axi.js");
  writeFileSync(execFile, "// stub cli\n", "utf-8");

  // npm 在 Windows 安裝的是無副檔名 wrapper shim（非 symlink），
  // Git Bash 執行它並 exec 相對於自身目錄的 .js。
  writeFileSync(
    join(pathDir, "gh-axi"),
    [
      "#!/bin/sh",
      'basedir=$(dirname "$0")',
      '  exec node  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
    ].join("\n"),
    "utf-8",
  );

  const savedPath = process.env.PATH;
  process.env.PATH = pathDir;
  try {
    installSessionStartHooks({
      marker: "gh-axi",
      execPath: execFile,
      binaryNames: ["gh-axi"],
      homeDir: home,
    });
  } finally {
    process.env.PATH = savedPath;
  }

  const settings = JSON.parse(
    readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
  );
  const command = settings.hooks.SessionStart[0].hooks[0].command;
  console.log(`[${label}] PATH 上的 npm wrapper shim 指向 exec`);
  console.log(`  exec 絕對路徑 : ${execFile}`);
  console.log(`  寫入的 hook 指令 : ${JSON.stringify(command)}`);
  console.log(
    command === "gh-axi"
      ? "  結果: 可攜的 gh-axi（跨機器有效）"
      : "  結果: 退回脆弱的絕對路徑（換機器即失效）",
  );
  rmSync(root, { recursive: true, force: true });
  return command;
}

run("Windows npm shim layout");
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm exec vitest run test/hooks.test.ts`（packages/axi-sdk-js，37 tests 全數通過，含新增的 resolvePortableHookCommand shim 比對、extractNpmShimScriptPath 對 Git Bash／.cmd shim 的解析、以及 installSessionStartHooks 寫入真實檔案系統 shim 的整合測試）</code>
- <code>端到端重現：`node /tmp/no-mistakes-evidence/01KWBVNED1V3H5XP6ZDST0TQ1Z/repro.mjs`，以真實檔案系統模擬 Windows npm wrapper-shim 佈局，呼叫實際的 installSessionStartHooks 並讀回 ~/.claude/settings.json 的 hook 指令</code>
- `前後對照：將 src/hooks.ts 暫換為 base 版（743619a）重新 build 跑同一 repro，確認修復前寫入絕對路徑、修復後寫入可攜的 "gh-axi"，再還原並 rebuild（git status 乾淨）`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
