### PR TITLE
fix(axi-sdk-js): resolve portable hook command from npm wrapper shims

### DIFF
--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -164,6 +164,8 @@ Claude Code and Codex receive native `SessionStart` hooks, while OpenCode receiv
 
 Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
 
+On Windows, npm global bins are wrapper shims (`.cmd` files and extensionless Git Bash scripts) rather than symlinks, so the realpath match never succeeds. The resolver also parses each shim to recover the script it ultimately runs and matches that against the executable, so the plain binary name still works there.
+
 For custom wrappers, pass `binaryNames: ["my-axi"]` to `installSessionStartHooks()`.
 
 ## Development

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -58,6 +58,7 @@ export interface PortableHookCommandContext {
   pathEntries: string[];
   pathExtensions: string[];
   resolveRealPath: (absolutePath: string) => string | undefined;
+  resolveShimTarget?: (shimPath: string) => string | undefined;
 }
 
 function isManagedHook(hook: HookEntry | undefined, marker: string): boolean {
@@ -379,6 +380,14 @@ export function resolvePortableHookCommand(
         if (resolvedCandidate && resolvedCandidate === resolvedExec) {
           return name;
         }
+
+        // npm global bins on Windows are wrapper shims, not symlinks, so the
+        // realpath check above never matches. Parse the shim to recover the
+        // script it ultimately runs and compare that instead.
+        const shimTarget = context.resolveShimTarget?.(candidate);
+        if (shimTarget && shimTarget === resolvedExec) {
+          return name;
+        }
       }
     }
   }
@@ -386,12 +395,30 @@ export function resolvePortableHookCommand(
   return execPath;
 }
 
+const NPM_SHIM_SCRIPT_PATTERNS = [
+  // Git Bash / POSIX shim: exec node "$basedir/node_modules/<pkg>/.../cli.js"
+  /"\$basedir\/([^"]+\.[cm]?js)"/,
+  // Windows .cmd shim: "%dp0%\node_modules\<pkg>\...\cli.js"
+  /%~?dp0%?[\\/]([^"\r\n]+\.[cm]?js)/i,
+];
+
+export function extractNpmShimScriptPath(content: string): string | undefined {
+  for (const pattern of NPM_SHIM_SCRIPT_PATTERNS) {
+    const match = content.match(pattern);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
 function buildDefaultPortableCommandContext(): PortableHookCommandContext {
   const rawPath = process.env.PATH ?? process.env.Path ?? "";
   const pathEntries = rawPath.split(delimiter).filter(Boolean);
   const pathExtensions =
     process.platform === "win32"
-      ? (process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")
+      ? // Git Bash resolves the extensionless shim, which PATHEXT omits.
+        ["", ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD").split(";")]
       : [""];
   return {
     pathEntries,
@@ -403,6 +430,19 @@ function buildDefaultPortableCommandContext(): PortableHookCommandContext {
           return undefined;
         }
         return realpathSync(absolutePath);
+      } catch {
+        return undefined;
+      }
+    },
+    resolveShimTarget: (shimPath) => {
+      try {
+        const relative = extractNpmShimScriptPath(
+          readFileSync(shimPath, "utf-8"),
+        );
+        if (!relative) {
+          return undefined;
+        }
+        return realpathSync(resolve(dirname(shimPath), relative));
       } catch {
         return undefined;
       }

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -16,6 +16,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   computeCodexConfigUpdate,
   computeSessionStartHookUpdate,
+  extractNpmShimScriptPath,
   installSessionStartHooks,
   resolvePortableHookCommand,
   shouldInstallHooksForNodeAxiExecPath,
@@ -304,6 +305,75 @@ describe("resolvePortableHookCommand", () => {
     const context = makeContext({ [exec]: exec });
     expect(resolvePortableHookCommand(exec, [], "gh-axi", context)).toBe(exec);
   });
+
+  it("returns the plain binary name when a shim wrapper targets the exec file", () => {
+    const exec = "/npm/node_modules/gh-axi/dist/bin/gh-axi.js";
+    const shim = join("/npm", "gh-axi");
+    const context = {
+      pathEntries: ["/npm"],
+      pathExtensions: ["", ".CMD"],
+      // npm shims are wrappers, so realpath equals the shim itself, never exec.
+      resolveRealPath: (p: string) => ({ [exec]: exec, [shim]: shim })[p],
+      resolveShimTarget: (p: string) => (p === shim ? exec : undefined),
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe("gh-axi");
+  });
+
+  it("ignores a shim wrapper that targets a different install", () => {
+    const exec = "/src/gh-axi/dist/bin/gh-axi.js";
+    const shim = join("/npm", "gh-axi");
+    const context = {
+      pathEntries: ["/npm"],
+      pathExtensions: ["", ".CMD"],
+      resolveRealPath: (p: string) => ({ [exec]: exec, [shim]: shim })[p],
+      resolveShimTarget: (p: string) =>
+        p === shim ? "/other/gh-axi.js" : undefined,
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe(exec);
+  });
+});
+
+describe("extractNpmShimScriptPath", () => {
+  it("reads the script reference from a Git Bash shim", () => {
+    const shim = [
+      "#!/bin/sh",
+      'basedir=$(dirname "$(echo "$0" | sed -e \'s,\\\\,/,g\')")',
+      'if [ -x "$basedir/node" ]; then',
+      '  exec "$basedir/node"  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      "else",
+      '  exec node  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      "fi",
+    ].join("\n");
+
+    expect(extractNpmShimScriptPath(shim)).toBe(
+      "node_modules/gh-axi/dist/bin/gh-axi.js",
+    );
+  });
+
+  it("reads the script reference from a Windows .cmd shim", () => {
+    const shim = [
+      "@ECHO off",
+      "SETLOCAL",
+      "SET dp0=%~dp0",
+      '"%_prog%"  "%dp0%\\node_modules\\gh-axi\\dist\\bin\\gh-axi.js" %*',
+    ].join("\r\n");
+
+    expect(extractNpmShimScriptPath(shim)).toBe(
+      "node_modules\\gh-axi\\dist\\bin\\gh-axi.js",
+    );
+  });
+
+  it("returns undefined when no script reference is present", () => {
+    expect(extractNpmShimScriptPath("#!/bin/sh\nexec node --version\n")).toBe(
+      undefined,
+    );
+  });
 });
 
 describe("shouldInstallHooksForNodeAxiExecPath", () => {
@@ -412,6 +482,43 @@ describe("installSessionStartHooks (portable command)", () => {
     const execFile = join(pkgBin, "gh-axi.js");
     writeFileSync(execFile, "// stub\n", "utf-8");
     symlinkSync(execFile, join(pathDir, "gh-axi"));
+
+    process.env.PATH = pathDir;
+
+    installSessionStartHooks({
+      marker: "gh-axi",
+      execPath: execFile,
+      binaryNames: ["gh-axi"],
+      homeDir: home,
+    });
+
+    const settings = JSON.parse(
+      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+    );
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+  });
+
+  it("writes the plain binary name when a PATH npm wrapper shim targets the exec file", () => {
+    const home = join(tmp, "home");
+    const pathDir = join(tmp, "path-bin");
+    const pkgBin = join(pathDir, "node_modules", "gh-axi", "dist", "bin");
+    mkdirSync(home, { recursive: true });
+    mkdirSync(pkgBin, { recursive: true });
+
+    const execFile = join(pkgBin, "gh-axi.js");
+    writeFileSync(execFile, "// stub\n", "utf-8");
+
+    // npm installs an extensionless wrapper shim on PATH (not a symlink); Git
+    // Bash runs it and it execs the .js relative to its own directory.
+    writeFileSync(
+      join(pathDir, "gh-axi"),
+      [
+        "#!/bin/sh",
+        'basedir=$(dirname "$0")',
+        '  exec node  "$basedir/node_modules/gh-axi/dist/bin/gh-axi.js" "$@"',
+      ].join("\n"),
+      "utf-8",
+    );
 
     process.env.PATH = pathDir;
 


### PR DESCRIPTION
Fixes the Windows SessionStart hook failure reported in
[chrome-devtools-axi#73](https://github.com/kunchenguid/chrome-devtools-axi/issues/73)


The root cause lives in `axi-sdk-js` (`installSessionStartHooks`), the shared SDK
that `chrome-devtools-axi` and the other `*-axi` CLIs use to install their hooks,
so fixing it here resolves the issue for every CLI built on the SDK.

## What Changed

- `resolvePortableHookCommand` now parses npm wrapper shims (Git Bash/POSIX
  `exec node "$basedir/.../cli.js"` and Windows `.cmd` `%dp0%\...\cli.js`) via a
  new optional `resolveShimTarget` hook and an `extractNpmShimScriptPath` helper,
  so a PATH entry matches the executable on Windows where global bins are wrapper
  shims rather than symlinks — restoring the portable binary name instead of
  writing an absolute path.
- The default Windows command context now includes the extensionless candidate
  ahead of `PATHEXT`, matching how Git Bash resolves the shim.
- Added `hooks.test.ts` coverage for shim matching and shim-script extraction,
  plus a README note documenting the Windows npm shim resolution.

## Root Cause

On macOS/Linux `npm i -g` creates a symlink, so the realpath-equality check
matched and the clean binary name was emitted. On Windows npm global bins are
standalone wrapper shims (`.cmd`/`.ps1`/extensionless), not symlinks, so
`realpath(shim)` never equals `realpath(.js)` and the resolver fell back to the
raw `dist/bin/*.js` path. Git Bash then ate the backslashes and split on the
space in the user-profile path, so the `SessionStart` hook failed with
`command not found` on every session start.

## Fix

- Keep the existing POSIX symlink path untouched.
- Add a wrapper-shim path: parse the npm shim to recover the script it ultimately
  runs and compare that realpath against the exec path.
- Include the extensionless Git Bash shim in the Windows candidate set.

## Testing

- `pnpm --dir packages/axi-sdk-js test` — 121 tests pass, including new coverage
  for shim matching, `extractNpmShimScriptPath` (Git Bash and `.cmd` shims), and
  an `installSessionStartHooks` integration test that writes to a real on-disk
  wrapper-shim layout.
- End-to-end before/after against real builds on the same simulated Windows npm
  wrapper-shim layout, using `chrome-devtools-axi` as in the report:

```text
=== Windows npm wrapper-shim hook resolution: before / after ===

--- BASE (before fix) ---
[Windows npm shim layout] npm wrapper shim on PATH points at exec
  exec absolute path   : /tmp/axi-shim-hxG82Z/npm-global/node_modules/chrome-devtools-axi/dist/bin/chrome-devtools-axi.js
  written hook command : "/tmp/axi-shim-hxG82Z/npm-global/node_modules/chrome-devtools-axi/dist/bin/chrome-devtools-axi.js"
  result: falls back to a brittle absolute path (breaks on another machine)

--- TARGET (this PR, after fix) ---
[Windows npm shim layout] npm wrapper shim on PATH points at exec
  exec absolute path   : /tmp/axi-shim-2Y5YlH/npm-global/node_modules/chrome-devtools-axi/dist/bin/chrome-devtools-axi.js
  written hook command : "chrome-devtools-axi"
  result: portable chrome-devtools-axi (works on any machine)
```

The bug only reproduces on Windows; this was developed and tested on WSL2 Ubuntu,
so the verification simulates the Windows npm wrapper-shim layout rather than
requiring a real Windows host.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)