### PR TITLE
feat: add Linear AXI prototype

### DIFF
--- a/.agents/skills/linear/SKILL.md
+++ b/.agents/skills/linear/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: linear
+description: Use Linear from Codex through the AXI-style `linear-axi` CLI, and compare behavior against Linear's official MCP server when requested.
+user-invocable: true
+---
+
+# Linear AXI
+
+Use this skill when the user asks to inspect or update Linear issues, compare
+Linear MCP with AXI, or run Linear workflows through a command-oriented agent
+interface.
+
+## Preconditions
+
+- `linear-axi` must be installed and on `PATH`.
+- `LINEAR_API_KEY` or `LINEAR_TOKEN` must be set for direct API access.
+- For MCP comparison, Codex should also have Linear MCP configured:
+
+```sh
+codex mcp add linear --url https://mcp.linear.app/mcp
+codex mcp login linear
+```
+
+Codex remote MCP support may require this in `~/.codex/config.toml`:
+
+```toml
+[features]
+experimental_use_rmcp_client = true
+```
+
+## AXI Commands
+
+Start with the home view:
+
+```sh
+linear-axi
+```
+
+Common read operations:
+
+```sh
+linear-axi issues --assigned --limit 20
+linear-axi issue get LIN-123
+linear-axi states
+```
+
+Write operations:
+
+```sh
+linear-axi issue comment LIN-123 --body "..."
+linear-axi issue update LIN-123 --state-id "<workflow-state-id>"
+```
+
+## Comparison Protocol
+
+When comparing Linear MCP and Linear AXI, run the same task both ways and record:
+
+- task
+- command or MCP tool sequence
+- number of calls
+- result quality
+- error handling
+- whether a human can reproduce the action from the transcript
+
+Prefer read-only tasks first. Ask before write operations unless the user has
+already explicitly authorized the exact Linear mutation.

--- a/docs/mcp-vs-axi-linear.md
+++ b/docs/mcp-vs-axi-linear.md
@@ -1,0 +1,43 @@
+# Linear MCP vs Linear AXI
+
+Linear has an official remote MCP server at `https://mcp.linear.app/mcp`. Codex
+can configure it with:
+
+```sh
+codex mcp add linear --url https://mcp.linear.app/mcp
+codex mcp login linear
+```
+
+`linear-axi` is a direct CLI wrapper around Linear's API. It is not a replacement
+for MCP yet; it is a comparison surface that makes every agent action explicit
+and reproducible.
+
+## Hypothesis
+
+- MCP should be better for native client integration and OAuth.
+- AXI should be easier to audit, replay, diff, and compare because each operation
+  is a shell command with compact output.
+
+## Benchmark Tasks
+
+| Task                         | Linear MCP | Linear AXI                                       | Winner | Notes      |
+| ---------------------------- | ---------- | ------------------------------------------------ | ------ | ---------- |
+| Show my assigned issues      | TBD        | `linear-axi issues --assigned --limit 20`        | TBD    | Read-only  |
+| Summarize one issue          | TBD        | `linear-axi issue get LIN-123`                   | TBD    | Read-only  |
+| Find allowed workflow states | TBD        | `linear-axi states`                              | TBD    | Read-only  |
+| Add a comment                | TBD        | `linear-axi issue comment LIN-123 --body "..."`  | TBD    | Write      |
+| Move an issue                | TBD        | `linear-axi issue update LIN-123 --state-id ...` | TBD    | Write      |
+| Recover from missing auth    | TBD        | unset `LINEAR_API_KEY`; run `linear-axi`         | TBD    | Error path |
+
+## Metrics
+
+- Calls: how many MCP tool calls or shell commands were needed.
+- Context: whether the agent needed hidden state to act correctly.
+- Auditability: whether the transcript can be replayed by a human.
+- Safety: whether writes require explicit, inspectable commands.
+- Failure quality: whether auth, missing ID, and permission errors are actionable.
+
+## Notes
+
+Linear MCP is the production integration path today. Keep AXI narrow until it
+proves better on concrete tasks.

--- a/packages/linear-axi/package.json
+++ b/packages/linear-axi/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "linear-axi",
+  "version": "0.1.0",
+  "description": "AXI-style CLI for Linear issues, workflow states, and comments",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/kunchenguid/axi.git",
+    "directory": "packages/linear-axi"
+  },
+  "bin": {
+    "linear-axi": "./dist/index.js"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "LICENSE",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "prepublishOnly": "npm run build"
+  },
+  "dependencies": {
+    "axi-sdk-js": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/linear-axi/src/cli.ts
+++ b/packages/linear-axi/src/cli.ts
@@ -1,0 +1,229 @@
+import { AxiError, runAxiCli } from "axi-sdk-js";
+import {
+  LinearApiError,
+  createComment,
+  getIssue,
+  getViewer,
+  listAssignedIssues,
+  listWorkflowStates,
+  updateIssue,
+  type LinearIssue,
+} from "./linear.js";
+
+const VERSION = "0.1.0";
+
+type AxiOutput = Record<string, unknown>;
+
+function flag(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) return undefined;
+  return args[index + 1];
+}
+
+function intFlag(args: string[], name: string, fallback: number): number {
+  const value = flag(args, name);
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function requireFlag(args: string[], name: string): string {
+  const value = flag(args, name);
+  if (!value) {
+    throw new AxiError(`Missing ${name}`, "VALIDATION_ERROR", [
+      "Run `linear-axi --help` for usage",
+    ]);
+  }
+  return value;
+}
+
+function issueRow(issue: LinearIssue): Record<string, unknown> {
+  return {
+    id: issue.identifier,
+    title: issue.title,
+    state: issue.state?.name ?? "",
+    priority: issue.priority ?? "",
+    updated: issue.updatedAt ?? "",
+    url: issue.url,
+  };
+}
+
+async function home(): Promise<AxiOutput> {
+  const [viewer, issues] = await Promise.all([
+    getViewer(),
+    listAssignedIssues({ first: 8 }),
+  ]);
+
+  return {
+    workspace: viewer.organization?.name ?? "unknown",
+    viewer: `${viewer.name} <${viewer.email ?? "unknown"}>`,
+    assigned_issues: issues.map(issueRow),
+    help: [
+      "linear-axi issues --assigned --limit 20",
+      "linear-axi issue get <id>",
+      "linear-axi states",
+      'linear-axi issue comment <id> --body "..."',
+      "linear-axi issue update <id> --state-id <workflow-state-id>",
+    ],
+  };
+}
+
+async function issues(args: string[]): Promise<AxiOutput> {
+  const limit = intFlag(args, "--limit", 20);
+  const rows = await listAssignedIssues({ first: limit });
+  return {
+    count: rows.length,
+    issues: rows.map(issueRow),
+  };
+}
+
+async function issue(args: string[]): Promise<AxiOutput> {
+  const [action, id] = args;
+  if (!action || !id) {
+    throw new AxiError(
+      "Expected `issue <get|comment|update> <id>`",
+      "VALIDATION_ERROR",
+      [
+        "linear-axi issue get LIN-123",
+        'linear-axi issue comment LIN-123 --body "..."',
+        "linear-axi issue update LIN-123 --state-id <workflow-state-id>",
+      ],
+    );
+  }
+
+  if (action === "get") {
+    const item = await getIssue(id);
+    if (!item) {
+      throw new AxiError(`Issue not found: ${id}`, "NOT_FOUND", [
+        "Check the issue identifier or UUID",
+      ]);
+    }
+    return {
+      issue: {
+        id: item.identifier,
+        title: item.title,
+        state: item.state?.name ?? "",
+        assignee: item.assignee?.name ?? "unassigned",
+        team: item.team?.key ?? "",
+        project: item.project?.name ?? "",
+        priority: item.priority ?? "",
+        url: item.url,
+        labels:
+          item.labels?.nodes?.map((label) => label.name).filter(Boolean) ?? [],
+        description: item.description ?? "",
+      },
+      comments: (item.comments?.nodes ?? []).map((comment) => ({
+        author: comment.user?.name ?? "",
+        created: comment.createdAt ?? "",
+        body: comment.body ?? "",
+      })),
+    };
+  }
+
+  if (action === "comment") {
+    const body = requireFlag(args, "--body");
+    const result = await createComment(id, body);
+    return {
+      success: result.success,
+      comment: result.comment?.id ?? "",
+      url: result.comment?.url ?? "",
+    };
+  }
+
+  if (action === "update") {
+    const stateId = requireFlag(args, "--state-id");
+    const result = await updateIssue(id, { stateId });
+    return {
+      success: result.success,
+      issue: {
+        id: result.issue?.identifier ?? "",
+        state: result.issue?.state?.name ?? "",
+        url: result.issue?.url ?? "",
+      },
+    };
+  }
+
+  throw new AxiError(`Unknown issue action: ${action}`, "VALIDATION_ERROR", [
+    "linear-axi issue get LIN-123",
+  ]);
+}
+
+async function states(args: string[]): Promise<AxiOutput> {
+  const teamId = flag(args, "--team-id");
+  const rows = await listWorkflowStates({ teamId });
+  return {
+    count: rows.length,
+    states: rows.map((state) => ({
+      id: state.id,
+      name: state.name ?? "",
+      type: state.type ?? "",
+      team: state.team?.key ?? "",
+    })),
+  };
+}
+
+function formatError(error: unknown): { output: string; exitCode: number } {
+  if (error instanceof LinearApiError) {
+    const details = error.details
+      .map((detail) => detail.message)
+      .filter(Boolean);
+    return {
+      output:
+        [
+          `error: ${error.message}`,
+          "code: LINEAR_API_ERROR",
+          ...details.map((detail) => `detail: ${detail}`),
+          "help[2]:",
+          "  Set LINEAR_API_KEY or LINEAR_TOKEN for direct Linear API access",
+          "  Run `linear-axi --help` for supported commands",
+        ].join("\n") + "\n",
+      exitCode: 1,
+    };
+  }
+
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    output: `error: ${message}\ncode: UNKNOWN\n`,
+    exitCode: 1,
+  };
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  await runAxiCli({
+    description:
+      "Linear issues, states, and comments through an AXI-style CLI.",
+    version: VERSION,
+    packageName: "linear-axi",
+    argv,
+    topLevelHelp: `Linear AXI exposes Linear as stable command output for agents.
+
+Usage:
+  linear-axi
+  linear-axi issues [--assigned] [--limit N]
+  linear-axi issue get <id>
+  linear-axi issue comment <id> --body <text>
+  linear-axi issue update <id> --state-id <stateId>
+  linear-axi states [--team-id <teamId>]
+
+Environment:
+  LINEAR_API_KEY or LINEAR_TOKEN must contain a Linear API key.
+`,
+    commands: {
+      issues,
+      issue,
+      states,
+    },
+    home,
+    getCommandHelp(command) {
+      if (command === "issue") {
+        return `Usage:
+  linear-axi issue get <id>
+  linear-axi issue comment <id> --body <text>
+  linear-axi issue update <id> --state-id <stateId>
+`;
+      }
+      return null;
+    },
+    formatError,
+  });
+}

--- a/packages/linear-axi/src/index.ts
+++ b/packages/linear-axi/src/index.ts
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+import { main } from "./cli.js";
+
+await main();

--- a/packages/linear-axi/src/linear.ts
+++ b/packages/linear-axi/src/linear.ts
@@ -1,0 +1,318 @@
+const GRAPHQL_ENDPOINT = "https://api.linear.app/graphql";
+
+export class LinearApiError extends Error {
+  details: Array<{ message?: string }>;
+
+  constructor(message: string, details: Array<{ message?: string }> = []) {
+    super(message);
+    this.name = "LinearApiError";
+    this.details = details;
+  }
+}
+
+export function requireApiKey(env = process.env): string {
+  const token = env.LINEAR_API_KEY || env.LINEAR_TOKEN;
+  if (!token) {
+    throw new LinearApiError("missing LINEAR_API_KEY or LINEAR_TOKEN");
+  }
+  return token;
+}
+
+export async function graphql<TData>(
+  query: string,
+  variables: Record<string, unknown> = {},
+  options: { token?: string; env?: NodeJS.ProcessEnv } = {},
+): Promise<TData> {
+  const token = options.token || requireApiKey(options.env);
+  const response = await fetch(GRAPHQL_ENDPOINT, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+
+  const body = (await response.json().catch(() => null)) as {
+    data?: TData;
+    errors?: Array<{ message?: string }>;
+  } | null;
+
+  if (!response.ok) {
+    throw new LinearApiError(
+      `Linear API returned HTTP ${response.status}`,
+      body?.errors || [],
+    );
+  }
+  if (body?.errors?.length) {
+    throw new LinearApiError("Linear API returned GraphQL errors", body.errors);
+  }
+  if (!body?.data) {
+    throw new LinearApiError("Linear API returned no data");
+  }
+  return body.data;
+}
+
+export interface LinearIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description?: string | null;
+  priority?: number | null;
+  url: string;
+  createdAt?: string;
+  updatedAt?: string;
+  assignee?: { name?: string | null; email?: string | null } | null;
+  creator?: { name?: string | null; email?: string | null } | null;
+  state?: { id?: string; name?: string | null; type?: string | null } | null;
+  team?: { id?: string; key?: string | null; name?: string | null } | null;
+  project?: { name?: string | null; url?: string | null } | null;
+  labels?: { nodes?: Array<{ name?: string | null }> };
+  comments?: {
+    nodes?: Array<{
+      id: string;
+      body?: string | null;
+      createdAt?: string;
+      user?: { name?: string | null; email?: string | null } | null;
+    }>;
+  };
+}
+
+export async function getViewer(): Promise<{
+  id: string;
+  name: string;
+  email?: string | null;
+  organization?: { name?: string | null; urlKey?: string | null } | null;
+}> {
+  const data = await graphql<{
+    viewer: {
+      id: string;
+      name: string;
+      email?: string | null;
+      organization?: { name?: string | null; urlKey?: string | null } | null;
+    };
+  }>(`
+    query Viewer {
+      viewer {
+        id
+        name
+        email
+        organization {
+          name
+          urlKey
+        }
+      }
+    }
+  `);
+  return data.viewer;
+}
+
+export async function listAssignedIssues({
+  first = 10,
+  includeArchived = false,
+}: {
+  first?: number;
+  includeArchived?: boolean;
+} = {}): Promise<LinearIssue[]> {
+  const data = await graphql<{
+    viewer: { assignedIssues: { nodes: LinearIssue[] } };
+  }>(
+    `
+      query AssignedIssues($first: Int!, $includeArchived: Boolean!) {
+        viewer {
+          assignedIssues(
+            first: $first
+            includeArchived: $includeArchived
+            orderBy: updatedAt
+          ) {
+            nodes {
+              id
+              identifier
+              title
+              priority
+              url
+              updatedAt
+              state {
+                name
+                type
+              }
+              team {
+                key
+                name
+              }
+            }
+          }
+        }
+      }
+    `,
+    { first, includeArchived },
+  );
+  return data.viewer.assignedIssues.nodes;
+}
+
+export async function getIssue(id: string): Promise<LinearIssue | null> {
+  const data = await graphql<{ issue: LinearIssue | null }>(
+    `
+      query Issue($id: String!) {
+        issue(id: $id) {
+          id
+          identifier
+          title
+          description
+          priority
+          url
+          createdAt
+          updatedAt
+          assignee {
+            name
+            email
+          }
+          creator {
+            name
+            email
+          }
+          state {
+            id
+            name
+            type
+          }
+          team {
+            id
+            key
+            name
+          }
+          project {
+            name
+            url
+          }
+          labels {
+            nodes {
+              name
+            }
+          }
+          comments(first: 10, orderBy: createdAt) {
+            nodes {
+              id
+              body
+              createdAt
+              user {
+                name
+                email
+              }
+            }
+          }
+        }
+      }
+    `,
+    { id },
+  );
+  return data.issue;
+}
+
+export async function listWorkflowStates({
+  teamId,
+  first = 50,
+}: {
+  teamId?: string;
+  first?: number;
+} = {}): Promise<
+  Array<{
+    id: string;
+    name?: string | null;
+    type?: string | null;
+    team?: { key?: string | null; name?: string | null } | null;
+  }>
+> {
+  const query = teamId
+    ? `
+      query WorkflowStates($teamId: String!, $first: Int!) {
+        workflowStates(first: $first, filter: { team: { id: { eq: $teamId } } }) {
+          nodes { id name type team { key name } }
+        }
+      }
+    `
+    : `
+      query WorkflowStates($first: Int!) {
+        workflowStates(first: $first) {
+          nodes { id name type team { key name } }
+        }
+      }
+    `;
+  const data = await graphql<{
+    workflowStates: {
+      nodes: Array<{
+        id: string;
+        name?: string | null;
+        type?: string | null;
+        team?: { key?: string | null; name?: string | null } | null;
+      }>;
+    };
+  }>(query, teamId ? { teamId, first } : { first });
+  return data.workflowStates.nodes;
+}
+
+export async function createComment(
+  issueId: string,
+  body: string,
+): Promise<{
+  success: boolean;
+  comment?: { id: string; url?: string | null; createdAt?: string } | null;
+}> {
+  const data = await graphql<{
+    commentCreate: {
+      success: boolean;
+      comment?: { id: string; url?: string | null; createdAt?: string } | null;
+    };
+  }>(
+    `
+      mutation CommentCreate($issueId: String!, $body: String!) {
+        commentCreate(input: { issueId: $issueId, body: $body }) {
+          success
+          comment {
+            id
+            url
+            createdAt
+          }
+        }
+      }
+    `,
+    { issueId, body },
+  );
+  return data.commentCreate;
+}
+
+export async function updateIssue(
+  issueId: string,
+  input: { stateId: string },
+): Promise<{
+  success: boolean;
+  issue?: LinearIssue | null;
+}> {
+  const data = await graphql<{
+    issueUpdate: { success: boolean; issue?: LinearIssue | null };
+  }>(
+    `
+      mutation IssueUpdate($issueId: String!, $input: IssueUpdateInput!) {
+        issueUpdate(id: $issueId, input: $input) {
+          success
+          issue {
+            id
+            identifier
+            title
+            url
+            state {
+              name
+              type
+            }
+            assignee {
+              name
+              email
+            }
+          }
+        }
+      }
+    `,
+    { issueId, input },
+  );
+  return data.issueUpdate;
+}

--- a/packages/linear-axi/tsconfig.json
+++ b/packages/linear-axi/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../axi-sdk-js/tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/plugins/opencode/axi-linear-axi.js
+++ b/plugins/opencode/axi-linear-axi.js
@@ -1,0 +1,89 @@
+// axi-sdk-js style opencode plugin: linear-axi
+import { spawn } from "node:child_process";
+
+const command = "linear-axi";
+const marker = "linear-axi";
+const ambientHeader = "## AXI ambient context: linear-axi";
+const timeoutMs = 10000;
+
+function directoryOrFallback(directory) {
+  return typeof directory === "string" && directory.length > 0
+    ? directory
+    : process.cwd();
+}
+
+function runAxiHomeView(cwd) {
+  return new Promise((resolve) => {
+    const child = spawn(command, [], {
+      cwd: directoryOrFallback(cwd),
+      env: process.env,
+      shell: false,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      child.kill("SIGTERM");
+      resolve(
+        "error: " +
+          marker +
+          " ambient context timed out after " +
+          timeoutMs +
+          "ms",
+      );
+    }, timeoutMs);
+
+    child.stdout?.setEncoding("utf-8");
+    child.stderr?.setEncoding("utf-8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr?.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("error", (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve("error: " + marker + " ambient context failed: " + error.message);
+    });
+    child.on("close", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(stdout.trim());
+        return;
+      }
+      const message = (
+        stderr ||
+        stdout ||
+        marker + " exited with code " + code
+      ).trim();
+      resolve("error: " + marker + " ambient context failed: " + message);
+    });
+  });
+}
+
+export const AxiLinearAxiAmbientContextPlugin = async ({ directory }) => {
+  const sessionCache = new Map();
+
+  return {
+    "experimental.chat.system.transform": async (input, output) => {
+      const sessionID = input.sessionID ?? "__global__";
+      let homeView = sessionCache.get(sessionID);
+      if (homeView === undefined) {
+        homeView = await runAxiHomeView(directory);
+        sessionCache.set(sessionID, homeView);
+      }
+
+      if (homeView.length === 0) return;
+      output.system.push(ambientHeader + "\n" + homeView);
+    },
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,19 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.19)(tsx@4.21.0)(yaml@2.8.4)
 
+  packages/linear-axi:
+    dependencies:
+      axi-sdk-js:
+        specifier: workspace:*
+        version: link:../axi-sdk-js
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.19
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
 packages:
 
   '@esbuild/aix-ppc64@0.27.7':


### PR DESCRIPTION
Adds a Linear AXI package, Codex skill, OpenCode ambient-context plugin, and MCP-vs-AXI comparison plan.\n\nValidation run locally:\n- pnpm --dir packages/axi-sdk-js run build\n- pnpm --dir packages/linear-axi run build\n- node packages/linear-axi/dist/index.js --help\n- node packages/linear-axi/dist/index.js (verified structured missing-auth output)