### PR TITLE
docs: add oracle-axi to community catalog

### DIFF
--- a/.no-mistakes/evidence/fm/oracle-axi-catalog-catalog-admission/source-review.md
+++ b/.no-mistakes/evidence/fm/oracle-axi-catalog-catalog-admission/source-review.md
@@ -1,0 +1,40 @@
+# oracle-axi catalog admission review
+
+Review target: `thatdudealso/oracle-axi` at source revision `4f4d3da6cfd1578d871fa3e23389264e3faf93ff` (repository `HEAD` on 2026-07-21).
+
+## Provenance
+
+- Source repository: https://github.com/thatdudealso/oracle-axi
+- Pinned entrypoint: `bin/oracle-axi.js`
+- Package metadata: `package.json`, version `0.1.0`, binary `oracle-axi: ./bin/oracle-axi.js`
+- No Git tag was advertised by `git ls-remote`; `npm view oracle-axi` returned registry `E404`. No released package exists, so released-package execution is not applicable.
+
+## Source inspection and observations
+
+The pinned entrypoint defines `home`, `services`, and `discover` handlers, validates command-specific flags before dependency calls, emits structured stdout, and adds actionable `help` commands. Representative source executions at the pinned revision produced:
+
+```text
+$ curl -fsSL https://raw.githubusercontent.com/thatdudealso/oracle-axi/4f4d3da6cfd1578d871fa3e23389264e3faf93ff/bin/oracle-axi.js | node -
+targets_count: 0
+targets: 0 Oracle targets detected in this workspace
+help[3]:
+  Run `oracle-axi doctor` to check Oracle readiness
+  Run `oracle-axi discover --full` to inspect project Oracle targets
+  Run `oracle-axi recommend --goal local-dev` to choose an Oracle path
+
+$ curl -fsSL https://raw.githubusercontent.com/thatdudealso/oracle-axi/4f4d3da6cfd1578d871fa3e23389264e3faf93ff/bin/oracle-axi.js | node - services --capability querying
+count: 1 of 12 Oracle domains
+services[1]{capability,domain,use}:
+  querying,"capped-reads|write-guards|result-truncation",run safe SQL with default read-only behavior
+help[1]:
+  Run `oracle-axi recommend --goal <inspect|create|schema|query|export|import|roles|performance|maintenance|plsql|cloud|local-dev>` for workflow paths
+
+$ curl -fsSL https://raw.githubusercontent.com/thatdudealso/oracle-axi/4f4d3da6cfd1578d871fa3e23389264e3faf93ff/bin/oracle-axi.js | node - discover --bogus
+error: unknown flag --bogus for `discover`
+help[1]:
+  valid flags for `discover`: --connect, --cwd, --fields, --full, --help, --password, --service, --tns-admin, --user, --wallet
+```
+
+The source paths inspected for these observations are `main`, `parseArgs`, `home`, `services`, `discover`, `formatHelp`, and `usageError` in `bin/oracle-axi.js`.
+
+Verdict: source inspection supports the proposed community catalog admission for the described AXI-facing behavior. This review does not claim released-package behavior because no release was available at the pinned review time.

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ AXIs built and maintained by the community:
 | [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis                 | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
 | [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery                | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
-| [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database      | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                         |
+| [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 
 <!-- generated:catalog-community:end -->
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Evaluated across 425 runs (17 tasks × 5 conditions × 5 repeats) using Claude S
 
 Claude Sonnet 4.6 is the model the published runs used, not a limit of the
 harness. Both benchmarks take `--model`, which is passed straight through to
-the agent CLI, so any Claude model works — for example
+the agent CLI, so any Claude model works - for example
 `--model claude-opus-4-6`. Results for other models are simply not published
 here, and they may respond differently to output format.
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ AXIs built and maintained by the community:
 | [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis                 | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
 | [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery                | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
+| [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database      | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                         |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -141,3 +141,8 @@ community:
     author: unional
     domain: Terminal multiplexers
     description: "Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output."
+  - name: oracle-axi
+    url: https://github.com/thatdudealso/oracle-axi
+    author: thatdudealso
+    domain: Oracle Database
+    description: "Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows."

--- a/docs/index.html
+++ b/docs/index.html
@@ -683,6 +683,20 @@
                     contract with token-efficient output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/thatdudealso/oracle-axi"
+                      ><code>oracle-axi</code></a
+                    >
+                  </td>
+                  <td>thatdudealso</td>
+                  <td>Oracle Database</td>
+                  <td>
+                    Discover, create, inspect, query, export, import, maintain,
+                    and diagnose Oracle databases through safe token-efficient
+                    CLI workflows.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## What Changed
- Added an `oracle-axi` entry to `catalog.yaml`'s `community` list (name, url, author, domain, description).
- Regenerated the corresponding `generated:catalog-community` regions in `README.md` and `docs/index.html` to include the new row.
- Refreshed catalog checks for the oracle-axi entry.

## Risk Assessment

✅ Low: Purely additive, single-sourced catalog entry (catalog.yaml plus generated README/docs regions); `docs:check` confirms the generated regions match catalog.yaml with no duplication or drift.

## Testing

Ran the repo's docs:check generator (passes — no drift between catalog.yaml and the generated README/docs/index.html regions) and its unit test suite (4/4 pass), then loaded docs/index.html in a real browser via a local static server to visually confirm the new oracle-axi row renders correctly in the community catalog table with correct name, author, domain, and description columns. All transient files (screenshots, temp HTTP server) were removed from the worktree afterward; git status is clean.

- Evidence: Rendered docs/index.html community catalog table showing the new oracle-axi row (local file: <code>/var/folders/6c/fcyqk9yj4dl5l_p5d21jqwcm0000gn/T/no-mistakes-evidence/01KX7BR9KNSB41N314AZNMAXDB/oracle-axi-catalog-row.png</code>)
<details>
<summary>Evidence: docs:check output confirming no drift between catalog.yaml and generated regions</summary>

```text
docs:check ok — generated regions match their sources
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node scripts/generate-docs.mjs --check (confirms README.md and docs/index.html generated regions match catalog.yaml exactly, no drift)`
- `node --test scripts/generate-docs.test.mjs (4/4 pass: HTML escaping, unsafe-protocol rejection, markdown link/table generation)`
- `Rendered docs/index.html via local static server (python3 -m http.server) and Playwright, scrolled to and screenshotted the community catalog table to visually confirm the oracle-axi row (name, author, domain, description) displays correctly alongside existing entries`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
