### PR TITLE
docs: add redis-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ AXIs built and maintained by the community:
 | [`aws-axi`](https://github.com/thatdudealso/aws-axi)                                               | thatdudealso       | AWS              | Discover, plan, provision, deploy, and inspect AWS services for hosting web, backend, database, and AI workloads through safe token-efficient CLI workflows. |
 | [`docker-axi`](https://github.com/thatdudealso/docker-axi)                                         | thatdudealso       | Docker           | Discover, build, run, debug, publish, inspect, and clean up Docker apps through safe token-efficient CLI workflows.                                          |
 | [`pg-axi`](https://github.com/thatdudealso/pg-axi)                                                 | thatdudealso       | PostgreSQL       | Discover, create, inspect, query, back up, restore, and maintain PostgreSQL databases through safe token-efficient CLI workflows.                            |
+| [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis            | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                  |
 
 Built an AXI? Follow the [contributor workflow](CONTRIBUTING.md) to add it to this list.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -568,6 +568,20 @@
                     CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/thatdudealso/redis-axi"
+                      ><code>redis-axi</code></a
+                    >
+                  </td>
+                  <td>thatdudealso</td>
+                  <td>Redis</td>
+                  <td>
+                    Discover, inspect, query, export, import, maintain, and
+                    diagnose Redis databases through safe token-efficient CLI
+                    workflows.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
## Intent

Add redis-axi to the AXI community catalog so it appears in the README and static axi.md catalog. The Redis CLI repo itself is already complete and validated; this change only adds the prepared catalog entry for that tool, matching the existing community table style and keeping generated or unrelated files untouched. Agent-backed no-mistakes review/test/document/lint stages are skipped because the configured Claude sub-agent is blocked by a session limit until 1:20pm America/New_York; equivalent local validation was run manually: redis-axi npm test and npm run skill:check, plus axi pnpm run format:check, pnpm run lint, pnpm --dir packages/axi-sdk-js run build, and pnpm --dir packages/axi-sdk-js test.

## What Changed

bf5d7ea docs: add redis-axi to community catalog

## Testing

- ⏭️ **Test** - skipped

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Review** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Document** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>⏭️ **Lint** - skipped</summary>

Step was skipped.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<!-- retrigger no-mistakes-required after no-mistakes body update -->