### PR TITLE
docs(catalog): add celery-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ AXIs built and maintained by the community:
 | [`elasticsearch-axi`](https://github.com/thatdudealso/elasticsearch-axi)                           | thatdudealso       | Elasticsearch    | Discover, inspect, query, index, map, snapshot, restore, diagnose, and operate Elasticsearch clusters through safe token-efficient CLI workflows.            |
 | [`kubernetes-axi`](https://github.com/thatdudealso/kubernetes-axi)                                 | thatdudealso       | Kubernetes       | Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows.                     |
 | [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis            | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
+| [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery           | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -126,3 +126,8 @@ community:
     author: thatdudealso
     domain: Redis
     description: "Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows."
+  - name: celery-axi
+    url: https://github.com/thatdudealso/celery-axi
+    author: thatdudealso
+    domain: Celery
+    description: "Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows."

--- a/docs/index.html
+++ b/docs/index.html
@@ -641,6 +641,20 @@
                     workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/thatdudealso/celery-axi"
+                      ><code>celery-axi</code></a
+                    >
+                  </td>
+                  <td>thatdudealso</td>
+                  <td>Celery</td>
+                  <td>
+                    Discover, inspect, run, debug, monitor, schedule, control,
+                    and safely operate Celery task queues through
+                    token-efficient CLI workflows.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

Add celery-axi to the AXI community catalog after creating and publishing the public thatdudealso/celery-axi project. The upstream change is intentionally limited to catalog.yaml plus generated README.md and docs/index.html output, using the exact community catalog metadata requested for Celery.

## What Changed

- Added a `celery-axi` entry to the community catalog in `catalog.yaml` (author `thatdudealso`, domain Celery), the single source for all community AXI catalog listings.
- Regenerated the `generated:catalog-community` regions in `README.md` and `docs/index.html` from the updated `catalog.yaml` via `pnpm run docs:gen`, adding the corresponding table row in each.

## Risk Assessment

✅ Low: Purely additive documentation change (one catalog.yaml entry plus its generated README.md/docs/index.html mirrors) with no code, logic, or config touched, and formatting matches existing entries.

## Testing

Ran the project's own single-source generation check (`pnpm run docs:check`), which regenerates README.md and docs/index.html from catalog.yaml and diffs against the committed output — it reported no drift, directly demonstrating that the new celery-axi entry was added correctly to catalog.yaml and consistently propagated to both generated surfaces. Also ran the generator's existing unit tests (all pass) and confirmed via HTTP request that the linked thatdudealso/celery-axi repository is live and public, satisfying the stated intent. No code changes were needed; only pnpm's gitignored node_modules were installed as an incidental toolchain side effect and left no trace in git status.

<details>
<summary>Evidence: docs:check output confirming catalog.yaml -&gt; README.md/docs/index.html generation matches</summary>

```text
$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
```
</details>
<details>
<summary>Evidence: HTTP check confirming public thatdudealso/celery-axi repo exists</summary>

```text
curl -s -o /dev/null -w "%{http_code}\n" https://github.com/thatdudealso/celery-axi
200
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm run docs:check` — confirms generated regions in README.md and docs/index.html match catalog.yaml (docs:check ok — generated regions match their sources)</code>
- <code>`node scripts/generate-docs.test.mjs` — 4/4 existing generator unit tests pass (HTML escaping, link protocol validation, markdown parenthesis handling, pipe/multiline table cells)</code>
- <code>`git status --porcelain` after running docs:check — confirms no drift between committed generated output and freshly regenerated output from catalog.yaml</code>
- <code>`curl -o /dev/null -w &#39;%{http_code}&#39; https://github.com/thatdudealso/celery-axi` — returned 200, confirming the linked public repo referenced by the new catalog entry actually exists</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
