### PR TITLE
docs: add kubernetes-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ AXIs built and maintained by the community:
 | [`aws-axi`](https://github.com/thatdudealso/aws-axi)                                               | thatdudealso       | AWS              | Discover, plan, provision, deploy, and inspect AWS services for hosting web, backend, database, and AI workloads through safe token-efficient CLI workflows. |
 | [`docker-axi`](https://github.com/thatdudealso/docker-axi)                                         | thatdudealso       | Docker           | Discover, build, run, debug, publish, inspect, and clean up Docker apps through safe token-efficient CLI workflows.                                          |
 | [`pg-axi`](https://github.com/thatdudealso/pg-axi)                                                 | thatdudealso       | PostgreSQL       | Discover, create, inspect, query, back up, restore, and maintain PostgreSQL databases through safe token-efficient CLI workflows.                            |
+| [`kubernetes-axi`](https://github.com/thatdudealso/kubernetes-axi)                                 | thatdudealso       | Kubernetes       | Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows.                     |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -101,3 +101,8 @@ community:
     author: thatdudealso
     domain: PostgreSQL
     description: "Discover, create, inspect, query, back up, restore, and maintain PostgreSQL databases through safe token-efficient CLI workflows."
+  - name: kubernetes-axi
+    url: https://github.com/thatdudealso/kubernetes-axi
+    author: thatdudealso
+    domain: Kubernetes
+    description: "Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows."

--- a/docs/index.html
+++ b/docs/index.html
@@ -571,6 +571,20 @@
                     CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/thatdudealso/kubernetes-axi"
+                      ><code>kubernetes-axi</code></a
+                    >
+                  </td>
+                  <td>thatdudealso</td>
+                  <td>Kubernetes</td>
+                  <td>
+                    Discover, inspect, deploy, debug, scale, roll out, expose,
+                    and clean up Kubernetes workloads through safe
+                    token-efficient CLI workflows.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

The developer wanted to add a new community catalog entry for "dynamodb-axi" to the kunchenguid/axi repository, following the creation of a public thatdudealso/dynamodb-axi project. The change needed to add a single catalog.yaml entry (author thatdudealso, domain DynamoDB, with a specified description and GitHub link) and then regenerate README.md and docs/index.html from catalog.yaml as the source of truth, since those files have generated regions that must never be hand-edited. The developer explicitly wanted to avoid touching release-please generated files (package.json version, CHANGELOG.md, .release-please-manifest.json) and required the change to pass through the project's "no-mistakes" contribution gate. During validation, the assistant's stated approach was to run `docs:check` to confirm the generated README/docs regions matched catalog.yaml exactly, then run the docs test suite to validate the new entry's schema/format against existing catalog entries.

## What Changed

- Added a `kubernetes-axi` entry to `catalog.yaml`'s community list (author `thatdudealso`, domain Kubernetes, with description and GitHub link).
- Regenerated the corresponding rows in `README.md` and `docs/index.html` from `catalog.yaml` to reflect the new entry in the generated catalog table sections.

## Risk Assessment

✅ Low: Docs-only catalog addition (catalog.yaml + regenerated README/docs/index.html regions) that exactly follows the existing entry pattern with no logic, schema, or generated-release-file changes.

## Testing

Ran `docs:check` and the `docs:test` suite, both passing, confirming the new kubernetes-axi catalog.yaml entry is correctly reflected in the generated README.md and docs/index.html regions with proper schema/escaping. Additionally rendered docs/index.html in a real browser via Playwright and screenshotted the new table row to visually confirm the end-user-facing catalog page displays the entry correctly. Confirmed release-please-guarded files were not modified. All checks passed with no issues found.

- Evidence: kubernetes-axi row rendered in docs/index.html (local file: <code>/var/folders/6c/fcyqk9yj4dl5l_p5d21jqwcm0000gn/T/no-mistakes-evidence/01KX8DKRRYKT6CX1JMXVXQ4YFY/kubernetes-axi-row.png</code>)
- Evidence: Full community catalog table rendered in docs/index.html (context) (local file: <code>/var/folders/6c/fcyqk9yj4dl5l_p5d21jqwcm0000gn/T/no-mistakes-evidence/01KX8DKRRYKT6CX1JMXVXQ4YFY/community-catalog-table.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm run docs:check` — confirms README.md and docs/index.html generated regions match catalog.yaml exactly</code>
- <code>`pnpm run docs:test` (scripts/generate-docs.test.mjs, node --test) — validates HTML escaping, link-protocol safety, and Markdown table generation used by the catalog entry</code>
- `Manual: served docs/index.html via a local static server and rendered it in a real browser (Playwright) to confirm the kubernetes-axi row appears correctly in the community catalog table with correct link, author, domain, and description`
- <code>`git diff ... -- packages/axi-sdk-js/package.json packages/axi-sdk-js/CHANGELOG.md .release-please-manifest.json` — confirms no release-please-generated files were touched</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
