### PR TITLE
docs: add redis-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ AXIs built and maintained by the community:
 | [`pg-axi`](https://github.com/thatdudealso/pg-axi)                                                 | thatdudealso       | PostgreSQL       | Discover, create, inspect, query, back up, restore, and maintain PostgreSQL databases through safe token-efficient CLI workflows.                            |
 | [`elasticsearch-axi`](https://github.com/thatdudealso/elasticsearch-axi)                           | thatdudealso       | Elasticsearch    | Discover, inspect, query, index, map, snapshot, restore, diagnose, and operate Elasticsearch clusters through safe token-efficient CLI workflows.            |
 | [`kubernetes-axi`](https://github.com/thatdudealso/kubernetes-axi)                                 | thatdudealso       | Kubernetes       | Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows.                     |
+| [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis            | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -111,3 +111,8 @@ community:
     author: thatdudealso
     domain: Kubernetes
     description: "Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows."
+  - name: redis-axi
+    url: https://github.com/thatdudealso/redis-axi
+    author: thatdudealso
+    domain: Redis
+    description: "Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows."

--- a/docs/index.html
+++ b/docs/index.html
@@ -599,6 +599,20 @@
                     token-efficient CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/thatdudealso/redis-axi"
+                      ><code>redis-axi</code></a
+                    >
+                  </td>
+                  <td>thatdudealso</td>
+                  <td>Redis</td>
+                  <td>
+                    Discover, inspect, query, export, import, maintain, and
+                    diagnose Redis databases through safe token-efficient CLI
+                    workflows.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

The developer needed PR #85 (branch docs/add-celery-axi-catalog-entry, adding a celery-axi entry to the AXI community catalog) rebased onto the updated base commit 694d8b9 after it developed merge conflicts. They asked the agent to resolve the conflicts with minimal, non-unrelated changes across catalog.yaml, README.md, and docs/index.html, and to verify the rebase completed cleanly before finishing. The underlying goal was to preserve both the base branch's newly added kubernetes-axi catalog entry and this branch's celery-axi entry, keeping the generated README/docs output in sync with catalog.yaml (per repo convention that those regions are generated, not hand-edited) rather than picking one entry over the other.</summary>
</invoke>

## What Changed

- Added a `redis-axi` entry to `catalog.yaml`'s community catalog list.
- Regenerated the `generated:catalog-community` regions in `README.md` and `docs/index.html` from `catalog.yaml` to include the new redis-axi row (link, author, domain, description).

## Risk Assessment

✅ Low: A single, well-formed catalog entry addition (redis-axi) mirroring the existing pattern exactly across catalog.yaml, README.md, and docs/index.html, with no logic changes and consistent formatting/structure with prior entries.

## Testing

Note: the supplied 'user intent' hint describes an unrelated celery-axi/PR#85 rebase scenario, but the actual branch (docs/add-redis-axi-catalog-entry-2) and diff only add a redis-axi entry to catalog.yaml with matching generated regions in README.md and docs/index.html — I tested against the real diff. `docs:check` passed (generated regions match catalog.yaml source), the doc-generator's own unit tests passed, and a live browser render of docs/index.html confirmed the redis-axi row displays correctly with the right link, author, domain, and description — screenshots captured as evidence. No code/product issues found; the docs-only change is correctly single-sourced per repo convention.

- Evidence: Rendered redis-axi row in docs/index.html community catalog table (local file: <code>/var/folders/6c/fcyqk9yj4dl5l_p5d21jqwcm0000gn/T/no-mistakes-evidence/01KX99Z4662G731S889RR136MZ/redis-axi-row.png</code>)
- Evidence: Rendered full community catalog table in docs/index.html including redis-axi (local file: <code>/var/folders/6c/fcyqk9yj4dl5l_p5d21jqwcm0000gn/T/no-mistakes-evidence/01KX99Z4662G731S889RR136MZ/redis-axi-catalog-table.png</code>)
<details>
<summary>Evidence: docs:check output confirming generated regions match catalog.yaml</summary>

```text
docs:check ok — generated regions match their sources
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install` (to restore missing `yaml` devDependency needed by the generator script)</code>
- <code>`node scripts/generate-docs.mjs --check` — confirms README.md and docs/index.html generated:catalog-community regions match catalog.yaml (repo convention: those regions must never be hand-edited and must be regenerated from catalog.yaml)</code>
- <code>`node --test scripts/generate-docs.test.mjs` — generator unit tests (HTML/Markdown escaping, link safety, table rendering)</code>
- <code>Manual render check: served docs/ via `python3 -m http.server` and loaded docs/index.html in a real browser (Playwright) to confirm the redis-axi row renders with correct link, author, domain, and description text</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
