### PR TITLE
docs: add linear-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ AXIs built and maintained by the community:
 | [`kubernetes-axi`](https://github.com/thatdudealso/kubernetes-axi)                                 | thatdudealso       | Kubernetes       | Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows.                     |
 | [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis            | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
 | [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery           | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
+| [`linear-axi`](https://github.com/pgalka0/linear-axi)                                              | pgalka0            | Linear           | List, view, create, update, and comment on Linear issues with token-efficient TOON output and next-step hints.                                               |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -131,3 +131,8 @@ community:
     author: thatdudealso
     domain: Celery
     description: "Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows."
+  - name: linear-axi
+    url: https://github.com/pgalka0/linear-axi
+    author: pgalka0
+    domain: Linear
+    description: "List, view, create, update, and comment on Linear issues with token-efficient TOON output and next-step hints."

--- a/docs/index.html
+++ b/docs/index.html
@@ -655,6 +655,19 @@
                     token-efficient CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/pgalka0/linear-axi"
+                      ><code>linear-axi</code></a
+                    >
+                  </td>
+                  <td>pgalka0</td>
+                  <td>Linear</td>
+                  <td>
+                    List, view, create, update, and comment on Linear issues
+                    with token-efficient TOON output and next-step hints.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

Add linear-axi to the community catalog so it is listed on axi.md

## What Changed

- Added a `linear-axi` entry to `catalog.yaml`, the single source for the community catalog.
- Regenerated the catalog regions in `README.md` and `docs/index.html` so the new tool is listed on axi.md.

## Risk Assessment

✅ Low: A documentation-only catalog addition with consistent entries across the source YAML and both generated HTML/Markdown regions, touching no functional code.

## Testing

Installed deps, ran the docs drift check (`docs:check` passed — the generated README/HTML regions match the edited catalog.yaml) and the docs generator unit tests (all pass), then rendered docs/index.html in headless Chromium to capture a screenshot of the community catalog showing the new linear-axi row (author pgalka0, domain Linear, TOON-output description) exactly as it appears on axi.md. The user intent — linear-axi listed in the community catalog on axi.md — is demonstrated end-to-end; worktree left clean.

- Evidence: Rendered axi.md community catalog with linear-axi row (highlighted) (local file: <code>/var/folders/s_/1_7vjdt96_x4s3bpgwj7fvp40000gn/T/no-mistakes-evidence/01KXDKP4TAN60HT34K84NGP6C5/community-catalog-linear-axi.png</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node scripts/generate-docs.mjs --check` — confirmed generated regions in README.md and docs/index.html match catalog.yaml (no drift; docs-check workflow would pass)</code>
- <code>`node --test scripts/generate-docs.test.mjs` — 4/4 catalog generation tests pass</code>
- <code>Rendered docs/index.html in headless Chromium and scrolled the community catalog to the new `linear-axi` row to capture reviewer-visible visual evidence</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
