### PR TITLE
docs: clarify that benchmarks support any Claude model

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Evaluated across 425 runs (17 tasks × 5 conditions × 5 repeats) using Claude S
 | GitHub MCP + ToolSearch | 82%      | $0.147     | 41.1s        | 8         |
 | MCP + Code Mode         | 84%      | $0.101     | 43.4s        | 7         |
 
+Claude Sonnet 4.6 is the model the published runs used, not a limit of the
+harness. Both benchmarks take `--model`, which is passed straight through to
+the agent CLI, so any Claude model works — for example
+`--model claude-opus-4-6`. Results for other models are simply not published
+here, and they may respond differently to output format.
+
 ## Quick Start
 
 Reference AXI implementations:

--- a/docs/index.html
+++ b/docs/index.html
@@ -1628,9 +1628,12 @@ $ chrome-devtools-axi click @1_161 \
             or dynamic web applications.
           </li>
           <li>
-            <strong>Single agent model.</strong> Only Claude Sonnet 4.6 is
-            evaluated. Other models may exhibit different sensitivities to
-            output format.
+            <strong>Single agent model evaluated.</strong> The published results
+            use Claude Sonnet 4.6. This is not a limit of the harness &mdash;
+            both benchmarks accept <code>--model</code> (for example
+            <code>--model claude-opus-4-6</code>) &mdash; but other models are
+            not evaluated here and may exhibit different sensitivities to output
+            format.
           </li>
           <li>
             <strong>Read-only tasks.</strong> The benchmark includes only read


### PR DESCRIPTION
## Intent

Answer issue #91: the README and website imply the benchmarks only support Claude Sonnet 4.6, but --model already accepts any Claude model with no allowlist. Correct the docs so the documented limitation matches reality

## What Changed

- Updated README to clarify that `--model` accepts any Claude model, not just Claude Sonnet 4.6 — published results use Sonnet 4.6, but other models are fully supported by the harness.
- Updated website documentation to remove the implied limitation; now clearly states that results for other models are simply not published here and may exhibit different performance characteristics.

## Risk Assessment

✅ Low: Pure documentation changes with no code modifications, accurate against implementation, and straightforward clarification of existing behavior.

## Testing

Verified documentation changes accurately reflect code behavior (no model restrictions in runner code). All 81 benchmark tests passed. Documentation generation check passed."

<details>
<summary>Evidence: Verification Summary</summary>

```text
# Documentation Change Verification

## Change Summary
Fixed issue #91: Clarified that benchmarks support any Claude model, not just Sonnet 4.6.

## Files Changed
1. **README.md** (lines 47-51): Added explanatory paragraph
2. **docs/index.html**: Updated "Single agent model" limitation description

## Verification Performed

### 1. Code Review - Model Parameter Handling

#### bench-github/src/runner.ts
- Line 205: `"--model", spec.model` passed to claude CLI
- Line 228: `"--model", spec.model` passed to codex CLI
- **Finding**: No model validation or allowlist. Parameter passed through directly.

#### bench-browser/src/runner.ts
- Line 191: `"--model", spec.model` passed to Claude CLI
- **Finding**: No model validation or allowlist. Parameter passed through directly.

### 2. Documentation Accuracy Check

**README.md** (new text):
`` `
Claude Sonnet 4.6 is the model the published runs used, not a limit of the
harness. Both benchmarks take `--model`, which is passed straight through to
the agent CLI, so any Claude model works — for example
`--model claude-opus-4-6`. Results for other models are simply not published
here, and they may respond differently to output format.
`` `

**docs/index.html** (new text):
`` `html
<strong>Single agent model evaluated.</strong> The published results
use Claude Sonnet 4.6. This is not a limit of the harness &mdash;
both benchmarks accept <code>--model</code> (for example
<code>--model claude-opus-4-6</code>) &mdash; but other models are
not evaluated here and may exhibit different sensitivities to output
format.
`` `

**Verification**: Documentation accurately reflects code behavior ✓

### 3. Test Results

**bench-github tests**:
- ✓ 2 test files
- ✓ 29 tests passed
- Duration: 762ms

**bench-browser tests**:
- ✓ 7 test files  
- ✓ 52 tests passed
- Duration: 917ms

### 4. Documentation Generation Check

`` `
$ pnpm docs:check
docs:check ok — generated regions match their sources
`` `

## Conclusion

The documentation changes accurately clarify that:
1. Claude Sonnet 4.6 was used for published benchmarks, not a limitation
2. The `--model` parameter is accepted by both benchmarks
3. Any Claude model can be used (e.g., `claude-opus-4-6`)
4. Results for other models are simply not published

The code confirms this: no validation or model restrictions exist. The model parameter is passed directly to the CLI tools.

All tests pass and documentation is properly generated.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm --dir bench-github test`
- `pnpm --dir bench-browser test`
- `pnpm docs:check`
- `Code review: bench-github/src/runner.ts lines 205, 228`
- `Code review: bench-browser/src/runner.ts line 191`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
