### PR TITLE
fix(axi-sdk-js): fail closed for unsafe Windows Node entrypoints

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -169,7 +169,7 @@ help[2]:
 
 - **Default app targets**: by default, support Claude Code, Codex, and OpenCode. Do not hard-code a single agent integration when the tool can reasonably support multiple agents
 - **Explicit opt-in**: register hooks or plugins only from a user-invoked setup command, not from ordinary CLI commands
-- **Portable commands**: hook commands should use a PATH-verified binary name when it resolves to the current executable, and fall back to the full absolute path otherwise. This keeps global installs portable while ensuring hooks do not accidentally run a different binary
+- **Portable commands**: hook commands should use a PATH-verified binary name when it resolves to the current executable, and fall back to the full absolute path otherwise — except on Windows, where a raw Node entrypoint (`.js`, `.cjs`, `.mjs`) must be skipped rather than exposed as an agent-executable command. This keeps global installs portable while ensuring hooks do not accidentally run a different binary
 - **Path repair**: setup commands should check existing hooks and update the executable path if it has changed (e.g., after reinstall or relocation)
 - **Idempotent**: repeated installs with the same path are silent no-ops
 - **Directory-scoped**: show only state relevant to the current working directory

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -162,7 +162,7 @@ Claude Code and Codex receive native `SessionStart` hooks, while OpenCode receiv
 
 ### Hook Command Portability
 
-Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`.
+Hook commands use a plain binary name such as `gh-axi` only when that name contains the hook marker and `binaryNames` resolves through the current `PATH` to the same executable; otherwise they use the absolute `execPath`. On Windows, if that fallback is a raw Node `.js`, `.cjs`, or `.mjs` entrypoint, setup skips the managed integrations rather than expose it as an agent-executable command. Ensure the matching named command or `.cmd` shim is on `PATH`, then rerun setup.
 
 On Windows, npm global bins are wrapper shims (`.cmd` files and extensionless Git Bash scripts) rather than symlinks, so the realpath match never succeeds. The resolver also parses each shim to recover the script it ultimately runs and matches that against the executable, so the plain binary name still works there.
 

--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -238,11 +238,13 @@ const timeoutMs = ${JSON.stringify(timeoutSeconds * 1000)};
 
 function runAxiHomeView(cwd) {
   return new Promise((resolve) => {
-    const child = spawn(command, [], {
+    const invocation = commandInvocation(command);
+    const child = spawn(invocation.file, invocation.args, {
       cwd: directoryOrFallback(cwd),
       env: process.env,
-      shell: false,
+      shell: invocation.shell,
       stdio: ["ignore", "pipe", "pipe"],
+      windowsHide: true,
     });
 
     let stdout = "";
@@ -282,6 +284,14 @@ function runAxiHomeView(cwd) {
       resolve("error: " + marker + " ambient context failed: " + message);
     });
   });
+}
+
+function commandInvocation(command) {
+  if (/\\.(?:cjs|js|mjs)$/i.test(command)) {
+    return { file: process.execPath, args: [command], shell: false };
+  }
+  const shell = process.platform === "win32" && !/\\.(?:com|exe)$/i.test(command);
+  return { file: command, args: [], shell };
 }
 
 function directoryOrFallback(directory) {
@@ -393,6 +403,10 @@ export function resolvePortableHookCommand(
   }
 
   return execPath;
+}
+
+function isUnsafeWindowsNodeEntrypoint(command: string): boolean {
+  return process.platform === "win32" && /\.(?:cjs|js|mjs)$/i.test(command);
 }
 
 const NPM_SHIM_SCRIPT_PATTERNS = [
@@ -563,6 +577,18 @@ export function installSessionStartHooks(
     marker,
     buildDefaultPortableCommandContext(),
   );
+
+  // Windows associates raw JavaScript files with user-configured apps, so a
+  // SessionStart hook must never expose one as an executable command. The
+  // generated OpenCode plugin would use Node safely internally, but Claude and
+  // Codex receive this string directly. Fail closed until the npm command shim
+  // can be resolved instead of writing a command that an agent might copy.
+  if (isUnsafeWindowsNodeEntrypoint(command)) {
+    options.onError?.(
+      `${marker}: skipped hook setup because no named command or .cmd shim resolves to ${execPath}`,
+    );
+    return;
+  }
 
   const home = options.homeDir ?? homedir();
   const jsonTargets = [

--- a/packages/axi-sdk-js/src/update.ts
+++ b/packages/axi-sdk-js/src/update.ts
@@ -460,7 +460,7 @@ function packageManagerExecutable(
   return command;
 }
 
-function shouldUseWindowsPackageManagerShell(
+function shouldUseWindowsPackageManagerCommandShim(
   command: string,
   platform: NodeJS.Platform,
 ): boolean {
@@ -470,18 +470,38 @@ function shouldUseWindowsPackageManagerShell(
   );
 }
 
+function packageManagerInvocation(
+  command: string,
+  args: string[],
+  platform: NodeJS.Platform,
+): { command: string; args: string[] } {
+  const executable = packageManagerExecutable(command, platform);
+  if (shouldUseWindowsPackageManagerCommandShim(command, platform)) {
+    return {
+      command: "cmd.exe",
+      args: ["/d", "/s", "/c", executable, ...args],
+    };
+  }
+  return { command: executable, args };
+}
+
 async function npmViewVersion(
   packageName: string,
   platform: NodeJS.Platform = process.platform,
 ): Promise<string | null> {
   try {
-    const command = packageManagerExecutable("npm", platform);
-    const { stdout } = await execFileAsync(
-      command,
+    const invocation = packageManagerInvocation(
+      "npm",
       ["view", packageName, "version"],
+      platform,
+    );
+    const { stdout } = await execFileAsync(
+      invocation.command,
+      invocation.args,
       {
         timeout: 20_000,
-        shell: shouldUseWindowsPackageManagerShell("npm", platform),
+        shell: false,
+        windowsHide: true,
       },
     );
     const version = stdout.trim();
@@ -651,14 +671,16 @@ async function defaultRunInstall(
 
   return new Promise<InstallResult>((resolve) => {
     const [command, ...args] = argv;
-    const child = spawn(
-      packageManagerExecutable(command, context.platform),
+    const invocation = packageManagerInvocation(
+      command,
       args,
-      {
-        stdio: ["ignore", "pipe", "pipe"],
-        shell: shouldUseWindowsPackageManagerShell(command, context.platform),
-      },
+      context.platform,
     );
+    const child = spawn(invocation.command, invocation.args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      shell: false,
+      windowsHide: true,
+    });
     child.stdout?.on("data", (chunk: string | Buffer) => {
       process.stderr.write(chunk);
     });

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -447,15 +447,21 @@ describe("runAxiCli subprocess integration", () => {
         new URL("./fixtures/version-bin.mjs", import.meta.url),
       );
       const viteNodePath = fileURLToPath(
-        new URL("../node_modules/.bin/vite-node", import.meta.url),
+        new URL(
+          `../node_modules/.bin/vite-node${process.platform === "win32" ? ".cmd" : ""}`,
+          import.meta.url,
+        ),
       );
-      const { stdout, stderr } = await execFileAsync(
-        viteNodePath,
-        [fixturePath, flag],
-        {
-          cwd: new URL("..", import.meta.url),
-        },
-      );
+      const command = process.platform === "win32" ? "cmd.exe" : viteNodePath;
+      const args =
+        process.platform === "win32"
+          ? ["/d", "/s", "/c", viteNodePath, fixturePath, flag]
+          : [fixturePath, flag];
+      const { stdout, stderr } = await execFileAsync(command, args, {
+        cwd: new URL("..", import.meta.url),
+        shell: false,
+        windowsHide: true,
+      });
 
       expect(stdout).toBe("9.9.9\n");
       expect(stderr).toBe("");

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -10,7 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join, normalize, relative } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
@@ -21,6 +21,34 @@ import {
   resolvePortableHookCommand,
   shouldInstallHooksForNodeAxiExecPath,
 } from "../src/hooks.js";
+
+function putNpmCommandOnPath(
+  root: string,
+  command: string,
+  execFile: string,
+): void {
+  const binDir = join(root, "path-bin");
+  const windowsTarget = relative(binDir, execFile).replaceAll("/", "\\");
+  const posixTarget = relative(binDir, execFile).replaceAll("\\", "/");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(
+    join(binDir, `${command}.cmd`),
+    ["@ECHO off", `node "%~dp0\\${windowsTarget}" %*`].join("\r\n"),
+    "utf-8",
+  );
+  const posixShim = join(binDir, command);
+  writeFileSync(
+    posixShim,
+    [
+      "#!/bin/sh",
+      'basedir=$(dirname "$0")',
+      `exec node "$basedir/${posixTarget}" "$@"`,
+    ].join("\n"),
+    "utf-8",
+  );
+  chmodSync(posixShim, 0o755);
+  process.env.PATH = [binDir, process.env.PATH].filter(Boolean).join(delimiter);
+}
 
 describe("computeSessionStartHookUpdate", () => {
   it("installs a managed hook when no hooks exist", () => {
@@ -203,11 +231,22 @@ describe("computeCodexConfigUpdate", () => {
 });
 
 describe("resolvePortableHookCommand", () => {
-  const makeContext = (mapping: Record<string, string>) => ({
-    pathEntries: ["/usr/local/bin", "/opt/homebrew/bin"],
-    pathExtensions: [""],
-    resolveRealPath: (p: string) => mapping[p],
-  });
+  const makeContext = (mapping: Record<string, string>) => {
+    const normalizedMapping = Object.fromEntries(
+      Object.entries(mapping).map(([path, target]) => [
+        normalize(path),
+        normalize(target),
+      ]),
+    );
+    return {
+      pathEntries: [
+        normalize("/usr/local/bin"),
+        normalize("/opt/homebrew/bin"),
+      ],
+      pathExtensions: [""],
+      resolveRealPath: (p: string) => normalizedMapping[normalize(p)],
+    };
+  };
 
   it("returns the plain binary name when PATH resolves to the same file", () => {
     const exec = "/opt/homebrew/lib/node_modules/gh-axi/dist/bin/gh-axi.js";
@@ -273,14 +312,14 @@ describe("resolvePortableHookCommand", () => {
 
   it("tries multiple path extensions", () => {
     const exec = "/real/gh-axi.js";
+    const mapping = {
+      [normalize(exec)]: normalize(exec),
+      [normalize("/usr/local/bin/gh-axi.CMD")]: normalize(exec),
+    };
     const context = {
-      pathEntries: ["/usr/local/bin"],
+      pathEntries: [normalize("/usr/local/bin")],
       pathExtensions: ["", ".EXE", ".CMD"],
-      resolveRealPath: (p: string) =>
-        ({
-          [exec]: exec,
-          "/usr/local/bin/gh-axi.CMD": exec,
-        })[p],
+      resolveRealPath: (p: string) => mapping[normalize(p)],
     };
 
     expect(
@@ -359,9 +398,11 @@ describe("extractNpmShimScriptPath", () => {
   it("reads the script reference from a Windows .cmd shim", () => {
     const shim = [
       "@ECHO off",
+      "GOTO start",
+      ":find_dp0",
       "SETLOCAL",
-      "SET dp0=%~dp0",
-      '"%_prog%"  "%dp0%\\node_modules\\gh-axi\\dist\\bin\\gh-axi.js" %*',
+      "CALL :find_dp0",
+      'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\gh-axi\\dist\\bin\\gh-axi.js" %*',
     ].join("\r\n");
 
     expect(extractNpmShimScriptPath(shim)).toBe(
@@ -433,6 +474,7 @@ describe("installSessionStartHooks (portable command)", () => {
 
     const execFile = join(pkgBin, "gh-axi.js");
     writeFileSync(execFile, "// stub\n", "utf-8");
+    putNpmCommandOnPath(tmp, "gh-axi", execFile);
     process.argv = ["node", execFile];
 
     installSessionStartHooks({ homeDir: home });
@@ -440,7 +482,7 @@ describe("installSessionStartHooks (portable command)", () => {
     const settings = JSON.parse(
       readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
     );
-    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
+    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
     expect(settings.hooks.SessionStart[0].hooks[0].timeout).toBe(10);
   });
 
@@ -471,32 +513,35 @@ describe("installSessionStartHooks (portable command)", () => {
     expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
   });
 
-  it("writes the plain binary name when a PATH symlink points at the exec file", () => {
-    const home = join(tmp, "home");
-    const pkgBin = join(tmp, "pkg", "dist", "bin");
-    const pathDir = join(tmp, "path-bin");
-    mkdirSync(home, { recursive: true });
-    mkdirSync(pkgBin, { recursive: true });
-    mkdirSync(pathDir, { recursive: true });
+  it.skipIf(process.platform === "win32")(
+    "writes the plain binary name when a PATH symlink points at the exec file",
+    () => {
+      const home = join(tmp, "home");
+      const pkgBin = join(tmp, "pkg", "dist", "bin");
+      const pathDir = join(tmp, "path-bin");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(pkgBin, { recursive: true });
+      mkdirSync(pathDir, { recursive: true });
 
-    const execFile = join(pkgBin, "gh-axi.js");
-    writeFileSync(execFile, "// stub\n", "utf-8");
-    symlinkSync(execFile, join(pathDir, "gh-axi"));
+      const execFile = join(pkgBin, "gh-axi.js");
+      writeFileSync(execFile, "// stub\n", "utf-8");
+      symlinkSync(execFile, join(pathDir, "gh-axi"));
 
-    process.env.PATH = pathDir;
+      process.env.PATH = pathDir;
 
-    installSessionStartHooks({
-      marker: "gh-axi",
-      execPath: execFile,
-      binaryNames: ["gh-axi"],
-      homeDir: home,
-    });
+      installSessionStartHooks({
+        marker: "gh-axi",
+        execPath: execFile,
+        binaryNames: ["gh-axi"],
+        homeDir: home,
+      });
 
-    const settings = JSON.parse(
-      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
-    );
-    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
-  });
+      const settings = JSON.parse(
+        readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+      );
+      expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+    },
+  );
 
   it("writes the plain binary name when a PATH npm wrapper shim targets the exec file", () => {
     const home = join(tmp, "home");
@@ -535,72 +580,141 @@ describe("installSessionStartHooks (portable command)", () => {
     expect(settings.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
   });
 
-  it("keeps the absolute exec path when the binary is not on PATH", () => {
-    const home = join(tmp, "home");
-    const pkgBin = join(tmp, "pkg", "dist", "bin");
-    const pathDir = join(tmp, "path-bin");
-    mkdirSync(home, { recursive: true });
-    mkdirSync(pkgBin, { recursive: true });
-    mkdirSync(pathDir, { recursive: true });
+  it.skipIf(process.platform !== "win32")(
+    "writes a named command for real npm .cmd shims in every generated integration",
+    () => {
+      const home = join(tmp, "home");
+      const pathDir = join(tmp, "path-bin");
+      const pkgBin = join(pathDir, "node_modules", "gh-axi", "dist", "bin");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(pkgBin, { recursive: true });
 
-    const execFile = join(pkgBin, "gh-axi.js");
-    writeFileSync(execFile, "// stub\n", "utf-8");
+      const execFile = join(pkgBin, "gh-axi.js");
+      writeFileSync(execFile, "// fixture\n", "utf-8");
+      writeFileSync(
+        join(pathDir, "gh-axi.cmd"),
+        [
+          "@ECHO off",
+          "GOTO start",
+          ":find_dp0",
+          "SET dp0=%~dp0",
+          "EXIT /b",
+          ":start",
+          "SETLOCAL",
+          "CALL :find_dp0",
+          'endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\\node_modules\\gh-axi\\dist\\bin\\gh-axi.js" %*',
+        ].join("\r\n"),
+        "utf-8",
+      );
+      process.env.PATH = pathDir;
 
-    process.env.PATH = pathDir;
+      installSessionStartHooks({
+        marker: "gh-axi",
+        execPath: execFile,
+        binaryNames: ["gh-axi"],
+        homeDir: home,
+      });
 
-    installSessionStartHooks({
-      marker: "gh-axi",
-      execPath: execFile,
-      binaryNames: ["gh-axi"],
-      homeDir: home,
-    });
+      const claude = JSON.parse(
+        readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+      );
+      const codex = JSON.parse(
+        readFileSync(join(home, ".codex", "hooks.json"), "utf-8"),
+      );
+      const openCode = readFileSync(
+        join(home, ".config", "opencode", "plugins", "axi-gh-axi.js"),
+        "utf-8",
+      );
 
-    const settings = JSON.parse(
-      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
-    );
-    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
-  });
+      expect(claude.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+      expect(codex.hooks.SessionStart[0].hooks[0].command).toBe("gh-axi");
+      expect(openCode).toContain('const command = "gh-axi";');
+      expect(openCode).not.toContain(execFile);
+    },
+  );
 
-  it("keeps the absolute exec path when PATH resolves to a different binary", () => {
-    const home = join(tmp, "home");
-    const pkgBin = join(tmp, "pkg", "dist", "bin");
-    const otherBin = join(tmp, "other", "dist", "bin");
-    const pathDir = join(tmp, "path-bin");
-    mkdirSync(home, { recursive: true });
-    mkdirSync(pkgBin, { recursive: true });
-    mkdirSync(otherBin, { recursive: true });
-    mkdirSync(pathDir, { recursive: true });
+  it.skipIf(process.platform !== "win32")(
+    "fails closed instead of writing raw Node entrypoints when no named command is on PATH",
+    () => {
+      const home = join(tmp, "home");
+      const pkgBin = join(tmp, "pkg", "dist", "bin");
+      const pathDir = join(tmp, "path-bin");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(pkgBin, { recursive: true });
+      mkdirSync(pathDir, { recursive: true });
 
-    const execFile = join(pkgBin, "gh-axi.js");
-    const otherFile = join(otherBin, "gh-axi.js");
-    writeFileSync(execFile, "// stub\n", "utf-8");
-    writeFileSync(otherFile, "// other\n", "utf-8");
-    symlinkSync(otherFile, join(pathDir, "gh-axi"));
+      const execFile = join(pkgBin, "gh-axi.js");
+      writeFileSync(execFile, "// stub\n", "utf-8");
 
-    process.env.PATH = pathDir;
+      process.env.PATH = pathDir;
 
-    installSessionStartHooks({
-      marker: "gh-axi",
-      execPath: execFile,
-      binaryNames: ["gh-axi"],
-      homeDir: home,
-    });
+      installSessionStartHooks({
+        marker: "gh-axi",
+        execPath: execFile,
+        binaryNames: ["gh-axi"],
+        homeDir: home,
+      });
 
-    const settings = JSON.parse(
-      readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
-    );
-    expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
-  });
+      expect(existsSync(join(home, ".claude", "settings.json"))).toBe(false);
+      expect(existsSync(join(home, ".codex", "hooks.json"))).toBe(false);
+      expect(
+        existsSync(
+          join(home, ".config", "opencode", "plugins", "axi-gh-axi.js"),
+        ),
+      ).toBe(false);
+    },
+  );
+
+  it.skipIf(process.platform === "win32")(
+    "keeps the absolute exec path when PATH resolves to a different binary",
+    () => {
+      const home = join(tmp, "home");
+      const pkgBin = join(tmp, "pkg", "dist", "bin");
+      const otherBin = join(tmp, "other", "dist", "bin");
+      const pathDir = join(tmp, "path-bin");
+      mkdirSync(home, { recursive: true });
+      mkdirSync(pkgBin, { recursive: true });
+      mkdirSync(otherBin, { recursive: true });
+      mkdirSync(pathDir, { recursive: true });
+
+      const execFile = join(pkgBin, "gh-axi.js");
+      const otherFile = join(otherBin, "gh-axi.js");
+      writeFileSync(execFile, "// stub\n", "utf-8");
+      writeFileSync(otherFile, "// other\n", "utf-8");
+      symlinkSync(otherFile, join(pathDir, "gh-axi"));
+
+      process.env.PATH = pathDir;
+
+      installSessionStartHooks({
+        marker: "gh-axi",
+        execPath: execFile,
+        binaryNames: ["gh-axi"],
+        homeDir: home,
+      });
+
+      const settings = JSON.parse(
+        readFileSync(join(home, ".claude", "settings.json"), "utf-8"),
+      );
+      expect(settings.hooks.SessionStart[0].hooks[0].command).toBe(execFile);
+    },
+  );
 });
 
 describe("installSessionStartHooks (OpenCode plugin)", () => {
   let tmp: string;
+  let originalPath: string | undefined;
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), "axi-sdk-js-opencode-"));
+    originalPath = process.env.PATH;
   });
 
   afterEach(() => {
+    if (originalPath === undefined) {
+      delete process.env.PATH;
+    } else {
+      process.env.PATH = originalPath;
+    }
     rmSync(tmp, { recursive: true, force: true });
   });
 
@@ -613,6 +727,7 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
     const execFile = join(tmp, "pkg", "dist", "bin", "gh-axi.js");
     mkdirSync(join(tmp, "pkg", "dist", "bin"), { recursive: true });
     writeFileSync(execFile, "// stub\n", "utf-8");
+    putNpmCommandOnPath(tmp, "gh-axi", execFile);
 
     installSessionStartHooks({
       marker: "gh-axi",
@@ -626,9 +741,11 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
     expect(plugin).toContain("experimental.chat.system.transform");
     expect(plugin).toContain("## AXI ambient context: gh-axi");
     expect(plugin).toContain('ambientHeader + "\\n" + homeView');
-    expect(plugin).toContain(JSON.stringify(execFile));
-    expect(plugin).toContain("spawn(command, [],");
+    expect(plugin).toContain('const command = "gh-axi";');
+    expect(plugin).not.toContain(execFile);
+    expect(plugin).toContain("spawn(invocation.file, invocation.args,");
     expect(plugin).toContain("cwd: directory");
+    expect(plugin).toContain("windowsHide: true");
     expect(plugin).not.toContain("tool:");
   });
 
@@ -644,6 +761,7 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
       "utf-8",
     );
     chmodSync(execFile, 0o755);
+    putNpmCommandOnPath(tmp, "gh-axi", execFile);
 
     installSessionStartHooks({
       marker: "gh-axi",
@@ -676,6 +794,7 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
     mkdirSync(join(tmp, "new", "dist", "bin"), { recursive: true });
     writeFileSync(oldExec, "// old\n", "utf-8");
     writeFileSync(newExec, "// new\n", "utf-8");
+    putNpmCommandOnPath(tmp, "gh-axi", oldExec);
 
     installSessionStartHooks({
       marker: "gh-axi",
@@ -683,6 +802,7 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
       binaryNames: ["gh-axi"],
       homeDir: home,
     });
+    putNpmCommandOnPath(tmp, "gh-axi", newExec);
     installSessionStartHooks({
       marker: "gh-axi",
       execPath: newExec,
@@ -691,8 +811,9 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
     });
 
     const plugin = readFileSync(pluginPath(home), "utf-8");
-    expect(plugin).toContain(JSON.stringify(newExec));
-    expect(plugin).not.toContain(JSON.stringify(oldExec));
+    expect(plugin).toContain('const command = "gh-axi";');
+    expect(plugin).not.toContain(oldExec);
+    expect(plugin).not.toContain(newExec);
   });
 
   it("does not overwrite an unmarked OpenCode plugin file", () => {
@@ -707,10 +828,14 @@ describe("installSessionStartHooks (OpenCode plugin)", () => {
       "utf-8",
     );
     const errors: string[] = [];
+    const execFile = join(tmp, "pkg", "dist", "bin", "gh-axi.js");
+    mkdirSync(join(tmp, "pkg", "dist", "bin"), { recursive: true });
+    writeFileSync(execFile, "// stub\n", "utf-8");
+    putNpmCommandOnPath(tmp, "gh-axi", execFile);
 
     installSessionStartHooks({
       marker: "gh-axi",
-      execPath: join(tmp, "pkg", "dist", "bin", "gh-axi.js"),
+      execPath: execFile,
       binaryNames: ["gh-axi"],
       homeDir: home,
       onError: (message) => errors.push(message),

--- a/packages/axi-sdk-js/test/update.test.ts
+++ b/packages/axi-sdk-js/test/update.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { normalize } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { AxiError } from "../src/errors.js";
 import {
@@ -74,13 +75,18 @@ describe("isUpdateAvailable", () => {
 });
 
 function fakeFs(files: Record<string, string>): IdentityFs {
+  const normalizedFiles = Object.fromEntries(
+    Object.entries(files).map(([path, content]) => [normalize(path), content]),
+  );
   return {
-    existsSync: (path) => Object.prototype.hasOwnProperty.call(files, path),
+    existsSync: (path) =>
+      Object.prototype.hasOwnProperty.call(normalizedFiles, normalize(path)),
     readFileSync: (path) => {
-      if (!Object.prototype.hasOwnProperty.call(files, path)) {
+      const normalized = normalize(path);
+      if (!Object.prototype.hasOwnProperty.call(normalizedFiles, normalized)) {
         throw new Error(`ENOENT: ${path}`);
       }
-      return files[path];
+      return normalizedFiles[normalized];
     },
   };
 }
@@ -814,12 +820,13 @@ describe("default install runner", () => {
         }),
         env: {},
         fetchLatest: async () => "1.3.0",
+        platform: "linux",
       });
 
       expect(spawn).toHaveBeenCalledWith(
         "npm",
         ["install", "-g", "gh-axi@latest"],
-        { stdio: ["ignore", "pipe", "pipe"], shell: false },
+        { stdio: ["ignore", "pipe", "pipe"], shell: false, windowsHide: true },
       );
       expect(stdout.write).toHaveBeenCalledWith(
         "running: npm install -g gh-axi@latest\n",
@@ -894,15 +901,15 @@ describe("default install runner", () => {
 
       expect(spawn).toHaveBeenNthCalledWith(
         1,
-        "npm.cmd",
-        ["install", "-g", "gh-axi@latest"],
-        { stdio: ["ignore", "pipe", "pipe"], shell: true },
+        "cmd.exe",
+        ["/d", "/s", "/c", "npm.cmd", "install", "-g", "gh-axi@latest"],
+        { stdio: ["ignore", "pipe", "pipe"], shell: false, windowsHide: true },
       );
       expect(spawn).toHaveBeenNthCalledWith(
         2,
-        "pnpm.cmd",
-        ["add", "-g", "gh-axi@latest"],
-        { stdio: ["ignore", "pipe", "pipe"], shell: true },
+        "cmd.exe",
+        ["/d", "/s", "/c", "pnpm.cmd", "add", "-g", "gh-axi@latest"],
+        { stdio: ["ignore", "pipe", "pipe"], shell: false, windowsHide: true },
       );
     } finally {
       vi.doUnmock("node:child_process");


### PR DESCRIPTION
## What Changed

- Added `commandInvocation()` helper that routes raw `.js`/`.cjs`/`.mjs` entrypoints through `process.execPath` and sets `windowsHide: true` on all spawned processes, preventing unsafe shell association handling on Windows.
- Hook setup now skips managed integrations (Claude Code, Codex, OpenCode) when the resolved command is a raw Node entrypoint on Windows, falling back gracefully instead of exposing a command an agent might invoke directly.
- Package manager spawning in `update.ts` replaces `shell: true` with an explicit `cmd.exe /d /s /c` invocation wrapper on Windows, and all spawned processes now run with `shell: false` and `windowsHide: true`.

Tests expanded to cover the new fail-closed Windows paths and the `cmd.exe` invocation wrapper. SKILL.md portable-commands rule and README hook command portability docs updated to document the Windows exception.

## Risk Assessment

✅ Low: Well-scoped security fix with fail-closed semantics, thorough cross-platform test coverage, no behavioral regressions, and clean separation of concerns. The change only adds a guard that prevents hook installation when an unsafe command would be written, which is the correct defensive behavior.

## Testing

Full test suite for axi-sdk-js on Windows: 120 passed, 2 skipped (correctly platform-gated symlink tests). Windows-specific safety tests — fail-closed for raw Node entrypoints, named command resolution from .cmd shims, and cmd.exe package-manager invocation — all pass, confirming the fix works end-to-end on the target platform.

<details>
<summary>Evidence: Full test suite output on Windows</summary>

```text
packages/axi-sdk-js full test suite on Windows (win32):

Test Files  4 passed (4)
     Tests  120 passed | 2 skipped (122)

Key Windows-specific tests that exercise the new code:
- installSessionStartHooks (portable command) > writes a named command for real npm .cmd shims in every generated integration ✓
- installSessionStartHooks (portable command) > fails closed instead of writing raw Node entrypoints when no named command is on PATH ✓
- default install runner > runs Windows package-manager installs through command shims ✓
- installSessionStartHooks (OpenCode plugin) > writes a managed OpenCode plugin that injects AXI home context ✓ (validates commandInvocation in generated plugin)
- installSessionStartHooks (OpenCode plugin) > runs the generated OpenCode plugin and appends ambient context ✓ (validates spawn with invocation.file/args/windowsHide)

2 skipped tests are platform-gated (skipIf on win32) — correct behavior:
- writes the plain binary name when a PATH symlink points at the exec file (symlinks uncommon on Windows)
- keeps the absolute exec path when PATH resolves to a different binary (symlink-based test)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install`
- `npx vitest run test/hooks.test.ts test/update.test.ts test/cli.test.ts`
- <code>`npx vitest run` (full suite)</code>
- `npx vitest run test/hooks.test.ts --reporter=verbose`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
