### PR TITLE
docs: add glab-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ AXIs built and maintained by the community:
 | [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery                | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
+| [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -146,3 +146,8 @@ community:
     author: thatdudealso
     domain: Oracle Database
     description: "Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows."
+  - name: glab-axi
+    url: https://github.com/karotkriss/glab-axi
+    author: karotkriss
+    domain: GitLab
+    description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."

--- a/docs/index.html
+++ b/docs/index.html
@@ -697,6 +697,20 @@
                     CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/karotkriss/glab-axi"
+                      ><code>glab-axi</code></a
+                    >
+                  </td>
+                  <td>karotkriss</td>
+                  <td>GitLab</td>
+                  <td>
+                    Issues, merge requests, CI/CD pipelines, variables and
+                    secrets, releases, and raw API access. Wraps the official
+                    glab CLI with agent-ergonomic TOON output.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

Rebase the existing upstream PR #99 (docs: add glab-axi to community catalog) onto current kunchenguid/axi main and resolve its conflict. The change adds a single glab-axi entry to the community list in catalog.yaml; README.md and docs/index.html are GENERATED from catalog.yaml via 'pnpm run docs:gen' and must never be hand-merged. The conflict arose only because other catalog entries landed upstream and regenerated those two files. Resolution: took upstream's catalog.yaml, README.md, and docs/index.html wholesale, re-applied the one glab-axi community entry to catalog.yaml, then regenerated README.md and docs/index.html with docs:gen (docs:check reports zero drift; regeneration is idempotent). The final diff against upstream main is exactly one catalog.yaml entry plus its two regenerated outputs (3 files, +20/-0), nothing else. This must UPDATE existing PR #99 in place on the same fork branch karotkriss:fm/axi-catalog-glab-c2 - do NOT open a new PR. The PR body already carries the required 'Updates from git push no-mistakes' signature and must keep it. Note: a prior run on this branch was cancelled after a flaky/failed CI attempt at the pre-rebase head; this is the rebased, revalidated head.

## What Changed

- Added a `glab-axi` entry to the `community` list in `catalog.yaml` (author karotkriss, domain GitLab, pointing to `github.com/karotkriss/glab-axi`).
- Regenerated the corresponding rows in `README.md` and `docs/index.html` from `catalog.yaml` via `pnpm run docs:gen`, keeping the generated sections in sync.

## Risk Assessment

✅ Low: The change is a minimal, well-bounded docs-catalog addition (one YAML entry plus its two regenerated outputs, +20/-0 across 3 files); it matches the append-only convention of the existing catalog, and `pnpm run docs:check` confirms zero drift between catalog.yaml and the regenerated README.md/docs/index.html.

## Testing

Verified via git diff and the project's own docs:check/docs:gen scripts that the rebased head d784f52 (based on current upstream main cc7fb68) changes exactly catalog.yaml plus its two generated outputs by +20/-0 to add a single glab-axi community entry, that docs:check reports zero drift, and that regeneration is idempotent; the generator's unit tests also pass. Confirmed via gh-axi that PR #99 remains open on the same fork branch with the required pipeline signature in its body, and that its still-showing pre-rebase-conflict bot comment is expected since this worktree is the revalidated head awaiting the pipeline's own push step, not something this Test step should push itself. No issues found.

<details>
<summary>Evidence: docs:check zero-drift verification</summary>

```text
$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
EXIT_CODE=0
```
</details>
<details>
<summary>Evidence: docs:gen idempotency verification</summary>

```text
$ node scripts/generate-docs.mjs
generated regions already up to date
EXIT_CODE=0
$ git status --porcelain
(empty — no changes produced)
```
</details>
<details>
<summary>Evidence: Diff scope vs upstream main (cc7fb68..d784f52)</summary>

```text
README.md | 1 +
catalog.yaml | 5 +++++
docs/index.html | 14 ++++++++++++++
3 files changed, 20 insertions(+)
```
</details>
<details>
<summary>Evidence: glab-axi entry content diff</summary>

```text
catalog.yaml:
- name: glab-axi
url: https://github.com/karotkriss/glab-axi
author: karotkriss
domain: GitLab
description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."

README.md and docs/index.html each gained exactly one matching table row for glab-axi.
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Rebase** - skipped</summary>

- ⚠️ `README.md` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/axi-catalog-glab-c2
- ⚠️ `catalog.yaml` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/axi-catalog-glab-c2
- ⚠️ `docs/index.html` - merge conflict rebasing onto refs/remotes/no-mistakes-push/fm/axi-catalog-glab-c2

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat cc7fb68 d784f52 -- catalog.yaml README.md docs/index.html (confirms exactly 3 files, +20/-0)`
- `git diff cc7fb68 d784f52 (full content review of the added catalog entry and its two generated table rows)`
- `node scripts/generate-docs.mjs --check (docs:check — zero drift between catalog.yaml and generated README.md/docs/index.html)`
- `node scripts/generate-docs.mjs followed by git status --porcelain (docs:gen — confirms regeneration is idempotent, produces no diff)`
- `node --test scripts/generate-docs.test.mjs (docs:test — 4/4 generator unit tests pass)`
- `git rev-parse origin/main vs cc7fb68 (confirms base commit is current upstream main)`
- `grep -c 'name: glab-axi' catalog.yaml and grep for glab-axi across catalog.yaml/README.md/docs/index.html (confirms exactly one consistent entry, no duplicates)`
- `git show cddff0c --stat (confirms the intervening 'independent evidence' commit only touched policy docs, not catalog schema, so no additional fields are required)`
- `gh-axi pr view 99 --full and gh-axi api repos/kunchenguid/axi/pulls/99 (confirms PR #99 is open, targets base main, head branch fm/axi-catalog-glab-c2, and carries the 'Updates from git push no-mistakes' signature in its body)`
- `gh-axi pr view 99 --comments (confirms the visible bot comment is the pre-rebase merge-conflict nudge at 83ca8584, consistent with this worktree being the unpushed rebased revalidation head)`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
