### PR TITLE
docs: add gherkin-cli to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ AXIs built and maintained by the community:
 | [`kubernetes-axi`](https://github.com/thatdudealso/kubernetes-axi)                                 | thatdudealso       | Kubernetes       | Discover, inspect, deploy, debug, scale, roll out, expose, and clean up Kubernetes workloads through safe token-efficient CLI workflows.                     |
 | [`redis-axi`](https://github.com/thatdudealso/redis-axi)                                           | thatdudealso       | Redis            | Discover, inspect, query, export, import, maintain, and diagnose Redis databases through safe token-efficient CLI workflows.                                 |
 | [`celery-axi`](https://github.com/thatdudealso/celery-axi)                                         | thatdudealso       | Celery           | Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows.                      |
+| [`gherkin-cli`](https://github.com/cyberuni/gherkin-cli)                                           | unional            | Gherkin / BDD    | Parse, validate, and diff `.feature` files into a compact digest, with structured errors and a scenario-level change classifier for git refs.                |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -136,3 +136,8 @@ community:
     author: thatdudealso
     domain: Celery
     description: "Discover, inspect, run, debug, monitor, schedule, control, and safely operate Celery task queues through token-efficient CLI workflows."
+  - name: gherkin-cli
+    url: https://github.com/cyberuni/gherkin-cli
+    author: unional
+    domain: Gherkin / BDD
+    description: "Parse, validate, and diff `.feature` files into a compact digest, with structured errors and a scenario-level change classifier for git refs."

--- a/docs/index.html
+++ b/docs/index.html
@@ -669,6 +669,20 @@
                     token-efficient CLI workflows.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/cyberuni/gherkin-cli"
+                      ><code>gherkin-cli</code></a
+                    >
+                  </td>
+                  <td>unional</td>
+                  <td>Gherkin / BDD</td>
+                  <td>
+                    Parse, validate, and diff <code>.feature</code> files into a
+                    compact digest, with structured errors and a scenario-level
+                    change classifier for git refs.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

The developer wanted to register their published CLI cyber-mux (a cross-multiplexer pane-control tool for tmux, herdr, and WezTerm, already conforming to AXI ergonomics like --format text|json|agent, structured stdout errors, and help[N] disclosure blocks) in the AXI community catalog, following the repo's CONTRIBUTING.md. They required the change to be docs-only and deliberately minimal: exactly one entry appended to the community list in catalog.yaml with the existing key order, then README.md and docs/index.html regenerated via pnpm run docs:gen rather than hand-edited — noting the larger README diff was just column reflow from the new "Terminal multiplexers" domain label. They explicitly forbade touching source, SDK, benchmark, or workflow files, and forbade adding an entry to the official list. They had already run the CONTRIBUTING validation steps (format:check, lint, SDK build, 121 SDK tests) on Node 24, and mentioned an earlier pipeline run had wrongly targeted their fork before remotes were corrected to target kunchenguid/axi upstream. In this session they asked the agent to do a combined documentation-staleness and lint housekeeping pass over the change, fixing stale facts only in their authoritative locations and reporting only unresolved items.

## What Changed

- Added a `gherkin-cli` entry (cyberuni/gherkin-cli, domain "Gherkin / BDD") to the `community` list in `catalog.yaml`, matching the existing key order.
- Regenerated the marked catalog regions in `README.md` and `docs/index.html` via the docs generator so both stay in sync with `catalog.yaml`.
- Docs-only and additive; `pnpm run docs:check` and the docs generator tests pass with no drift.

## Risk Assessment

✅ Low: Docs-only change: one catalog.yaml entry plus the matching generated README/HTML rows, correctly formatted, correctly escaped, and consistent with the documented single-source workflow.

## Testing

Installed deps, ran the repo's docs generator in check mode (`docs:check` reports generated regions match catalog.yaml, so README.md and docs/index.html were regenerated rather than hand-edited) and the generator unit tests (4/4 pass). For end-user evidence I rendered docs/index.html in headless Chromium and captured the community catalog table, which shows the new gherkin-cli / unional / Gherkin / BDD row appended last with its description and working repo link, plus the matching README table row. The diff is additive across exactly the three docs files with no source, SDK, benchmark, or workflow changes and no official-list entry; worktree left clean. Note: the supplied user intent describes cyber-mux / "Terminal multiplexers", but the actual commit adds gherkin-cli — I validated the commit as written.

- Evidence: Rendered docs/index.html community catalog showing the new gherkin-cli row (local file: <code>/tmp/no-mistakes-evidence/01KXYGM29VDC6JPV2GRKQS3JZ6/docs-community-gherkin-cli.png</code>)
- Evidence: Close crop of the new catalog row (local file: <code>/tmp/no-mistakes-evidence/01KXYGM29VDC6JPV2GRKQS3JZ6/docs-community-row.png</code>)
<details>
<summary>Evidence: docs:check output</summary>

```text
$ pnpm run docs:check
> node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
```
</details>
<details>
<summary>Evidence: README.md community table row</summary>

```text
README.md:144:| [`gherkin-cli`](https://github.com/cyberuni/gherkin-cli) | unional | Gherkin / BDD | Parse, validate, and diff `.feature` files into a compact digest, with structured errors and a scenario-level change classifier for git refs. |
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 2 infos</summary>

- ℹ️ `catalog.yaml:140` - The change adds `gherkin-cli` (cyberuni/gherkin-cli, Gherkin/BDD), but the recorded session intent describes registering `cyber-mux` (a tmux/herdr/WezTerm pane-control CLI). The diff is internally consistent (catalog.yaml + both generated regions agree), so this is likely a stale intent hint — but worth confirming the intended tool was registered.
- ℹ️ `catalog.yaml:140` - Every other catalog entry (official and community) uses the `*-axi` name suffix; `gherkin-cli` is the first that does not. CONTRIBUTING.md does not mandate the suffix, so this is a maintainer-convention call rather than a rule violation.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm install --frozen-lockfile`
- <code>`pnpm run docs:check` (verifies README.md + docs/index.html generated regions match catalog.yaml)</code>
- <code>`pnpm run docs:test` (node --test scripts/generate-docs.test.mjs, 4/4 pass)</code>
- <code>Manual: rendered `docs/index.html` in headless Chromium via Playwright, scrolled to the community catalog table and screenshotted the new `gherkin-cli` row</code>
- <code>`git diff fbfe6d2 b8f3c63 --stat` to confirm only README.md, catalog.yaml, docs/index.html changed (additive)</code>
- <code>`git status --porcelain` to confirm no transient artifacts left in the worktree</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
