### PR TITLE
docs: require independent evidence for catalog admission

### DIFF
--- a/.no-mistakes/evidence/fm/axi-catalog-verification-vision-v1/catalog-policy-scenario-verification.md
+++ b/.no-mistakes/evidence/fm/axi-catalog-verification-vision-v1/catalog-policy-scenario-verification.md
@@ -1,0 +1,35 @@
+# AXI catalog policy scenario verification
+
+Tested target: `64f3c4b6fe5bdc70fa3098917e19d3a1e5db0d69`
+
+This artifact exercises the changed `VISION.md` as a generic catalog reviewer would use it. A positive verdict means the policy permits admission. It does not mean admission is automatic.
+
+## End-user decision scenarios
+
+| Proposal evidence available to the reviewer | Catalog | Expected verdict from `VISION.md` | Policy reason |
+| --- | --- | --- | --- |
+| Reviewer independently inspects source at pinned revision `abc123`, identifies the relevant entrypoint and output/error paths, and runs released package `1.2.3` through representative success, invalid-input error, no-results, and `--help` discovery paths. Direct observations cover every applicable AXI principle. | Community | Positive verdict is permitted | Independent pinned-source inspection, released-package execution, representative behavior, and exact provenance are all present. |
+| Same evidence as above, for a package selected by the project owner. | Official | Positive verdict is permitted for the owner-maintained catalog | The evidence bar applies to either catalog, while the official catalog remains maintained directly by the project owner and closed to contributed edits. |
+| Contributor supplies claims, pasted success/error transcripts, a generated diff, package metadata, and proof that the package name exists, but the reviewer cannot inspect source. | Community | Inconclusive or request source evidence | Contributor-provided verification and existence/metadata checks are insufficient on their own, and required independent source inspection is unavailable. |
+| Reviewer inspects a pinned source revision, but a runnable release exists and the reviewer does not execute it. | Either | Inconclusive or request execution evidence | A runnable release requires representative released-package success, error, and discovery execution. |
+| Reviewer independently inspects pinned source for a package with no runnable release and records the relevant files, entrypoint, and observable interface behavior across every applicable principle. | Either | Positive verdict can be considered without package execution | Execution is conditional on a runnable release existing; pinned source inspection and applicable-principle evidence remain mandatory. |
+| Reviewer executes a local contributor checkout or unreleased build and labels the results as behavior of release `2.0.0`. | Either | Inconclusive or corrected evidence request | The policy forbids attributing observations to a release or revision that was not inspected and requires the exact released version when execution applies. |
+| Independent source and released-package checks cover AXI-facing behavior, but do not audit unrelated dependency licensing or business risks. | Either | AXI admission review can proceed | Review is explicitly proportional to applicable AXI behavior and need not exhaustively audit unrelated package concerns. |
+| A proposal was already open when the policy changed, but only contributor claims and metadata are currently present. | Community | Inconclusive until the new evidence bar is met | The policy says every new package proposal may receive a positive verdict only after the required review. It contains no grandfathering exception. |
+
+## Acceptance-criteria trace
+
+- Both catalogs: "Every new package proposed for either catalog".
+- Independent pinned source: reviewer "must inspect the actual source at a pinned revision or release".
+- Released behavior: when runnable, reviewer executes representative "success, error, and discovery paths".
+- Complete AXI scope: observations must satisfy "all applicable AXI principles".
+- Exact provenance: verdict identifies the pinned revision/release, relevant files or code paths, released version, and exercised behavior.
+- Insufficient evidence: contributor claims, pasted verification, generated diffs, metadata, and existence checks do not suffice by themselves.
+- Fail closed: unavailable required inspection yields an inconclusive verdict or evidence request.
+- Ownership: official catalog remains maintained directly by the project owner and closed to contributed additions or edits.
+- Proportionality: unrelated exhaustive auditing is not required.
+- Self-contained scope: the policy names no Wheelhouse or downstream implementation.
+
+## Pending-proposal compatibility check
+
+At test time, the open community catalog proposals included PRs #79, #93, #98, #99, #101, #102, #104, and #105. The policy text itself applies the evidence bar to every new proposal without grandfathering. However, there is no PR for branch `fm/axi-catalog-verification-vision-v1`, so the required PR-level explanation of how pending proposals should be handled cannot yet be verified.

--- a/VISION.md
+++ b/VISION.md
@@ -18,11 +18,11 @@ Every new package proposed for either catalog may receive a positive admission v
 The reviewer must inspect the actual source at a pinned revision or release and, when a runnable release exists, execute that released package through representative success, error, and discovery paths.
 The observed interface and behavior must satisfy all applicable AXI principles, including agent-oriented ergonomics, structured and truthful outputs and errors, and discoverability.
 
-A PR description, contributor-provided transcript or pasted verification, generated catalog diff, package metadata, or existence check is insufficient evidence on its own.
-The verdict must identify the exact pinned source revision or release inspected and, when execution is required, the exact released package version and behavior exercised.
+Contributor assertions, pasted transcripts or other contributor-provided verification, generated diffs, package metadata, or existence checks are insufficient evidence on their own.
+The verdict must identify the exact pinned source revision or release, the specific relevant source components inspected, such as files, entrypoints, or code paths, and, when execution is required, the exact released package version and representative success, error, and discovery behavior exercised.
 It must distinguish direct observations from unverified claims and avoid attributing observations to a release or revision that was not inspected.
 If required source inspection or, when applicable, runnable-package execution cannot be completed, the verdict must remain inconclusive or request the missing evidence rather than recommend admission.
-Catalog review should verify AXI behavior without becoming an open-ended audit of unrelated package concerns.
+The identified source components and execution paths should be representative of applicable AXI behavior; exhaustive auditing of unrelated package concerns is not required.
 
 The official catalog is maintained directly by the project owner and is not open to contributed additions or edits.
 

--- a/VISION.md
+++ b/VISION.md
@@ -14,6 +14,16 @@ Small, objective corrections that improve clarity without changing meaning or be
 
 Contributions adding real, verifiable AXIs to the community catalog are welcome.
 
+Every new package proposed for either catalog may receive a positive admission verdict only after independent review of the package itself.
+The reviewer must inspect the actual source at a pinned revision or release and, when a runnable release exists, execute that released package through representative success, error, and discovery paths.
+The observed interface and behavior must satisfy all applicable AXI principles, including agent-oriented ergonomics, structured and truthful outputs and errors, and discoverability.
+
+A PR description, contributor-provided transcript or pasted verification, generated catalog diff, package metadata, or existence check is insufficient evidence on its own.
+The verdict must identify the exact pinned source revision or release inspected and, when execution is required, the exact released package version and behavior exercised.
+It must distinguish direct observations from unverified claims and avoid attributing observations to a release or revision that was not inspected.
+If required source inspection or, when applicable, runnable-package execution cannot be completed, the verdict must remain inconclusive or request the missing evidence rather than recommend admission.
+Catalog review should verify AXI behavior without becoming an open-ended audit of unrelated package concerns.
+
 The official catalog is maintained directly by the project owner and is not open to contributed additions or edits.
 
 ## SDKs


### PR DESCRIPTION
## Intent

Update AXI authoritative VISION.md so every new package proposed for either official or community catalog can receive a positive verdict only after an independent reviewer inspects actual source at a pinned revision or release and, when a runnable release exists, executes representative released-package success, error, and discovery paths. The policy must require evidence from real interface and behavior across all applicable AXI principles, identify exactly what source and package behavior were inspected without overstating provenance, reject contributor claims, pasted transcripts, generated diffs, metadata, and existence checks as sufficient evidence by themselves, and require an inconclusive verdict or evidence request when independent inspection is unavailable. Preserve the project owner distinction for the official catalog and keep review proportional to AXI behavior rather than unrelated auditing. Make VISION.md fully self-contained and machine-actionable for any generic vision-bound reviewer, with no Wheelhouse or downstream implementation details. Change only authoritative companion docs or tests that genuinely need it, never generated files, and explain compatibility for pending catalog proposals in the PR.

## What Changed

- Require independent inspection of pinned package source and, when available, representative released-package execution before admitting entries to either AXI catalog.
- Define acceptable evidence, provenance, fail-closed verdicts, AXI-focused review scope, and continued owner control of the official catalog.
- Add scenario-based verification covering both catalogs and clarify that pending proposals are not grandfathered into the previous evidence standard.
- Compatibility: Existing catalog entries are unaffected by this policy change. Pending, unmerged, and future catalog proposals are not grandfathered and must satisfy the new independent package-inspection evidence standard before receiving a positive verdict.

## Risk Assessment

✅ Low: The change is a focused documentation update that now satisfies the authoritative evidence, provenance, independence, proportionality, and catalog-ownership requirements without modifying generated files.

## Testing

Documentation tests, change-scope verification, machine-readable policy assertions, and eight end-user catalog-review scenarios passed, with reviewer-visible Markdown evidence captured. Browser screenshot evidence was unavailable, and no branch PR exists yet to verify the required pending-proposal compatibility note.

- Evidence: [Catalog policy scenario verification](https://github.com/kunchenguid/axi/blob/24c0d89189cf844c23ff5400c7bb95d219c037b8/.no-mistakes/evidence/fm/axi-catalog-verification-vision-v1/catalog-policy-scenario-verification.md)
- Outcome: ⚠️ 1 warning across 1 run (3m48s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 2 issues found → auto-fixed ✅</summary>

- 🚨 `VISION.md:22` - The required criterion says to “identify exactly what source and package behavior were inspected,” but this only requires the verdict to name the pinned revision or release. A reviewer could therefore report a commit SHA without identifying the inspected files, entrypoints, or code paths. Require the verdict to record the specific source components inspected as well as the exercised package behavior.
- 🚨 `VISION.md:21` - The required criterion rejects “contributor claims ... [and] generated diffs” as sufficient evidence by themselves, but this hunk only rejects PR descriptions and generated catalog diffs. Other contributor claims or generated source/package diffs remain permissible as sole evidence. State the exclusions generically so they cover all contributor claims and generated diffs.

🔧 Fix: Require concrete source evidence for catalog verdicts
✅ Re-checked - no issues remain.

</details>

<details>
<summary>⚠️ **Test** - 1 warning</summary>

- ⚠️ No PR exists for head branch `fm/axi-catalog-verification-vision-v1`, so the required PR-level explanation of compatibility for pending catalog proposals cannot yet be verified. Add and verify that explanation when the PR is created.
- `git diff --stat --name-status fbfe6d23f703ab2542d93bd6122846189950767b..64f3c4b6fe5bdc70fa3098917e19d3a1e5db0d69`
- `pnpm run docs:test`
- <code>Inline Node acceptance-contract check against `VISION.md` covering both catalogs, pinned-source inspection, released success/error/discovery paths, all applicable principles, exact provenance, insufficient evidence, fail-closed behavior, ownership, proportionality, and forbidden downstream coupling</code>
- <code>Manual eight-scenario generic-reviewer exercise recorded in `catalog-policy-scenario-verification.md`</code>
- `git diff --name-only fbfe6d23f703ab2542d93bd6122846189950767b..64f3c4b6fe5bdc70fa3098917e19d3a1e5db0d69`
- `gh-axi pr list --head fm/axi-catalog-verification-vision-v1`
- `Attempted browser rendering; no in-app browser backend was available`

</details>

<details>
<summary>⚠️ **Document** - 1 error</summary>

- 🚨 No pull request exists for branch `fm/axi-catalog-verification-vision-v1`, so the required PR-level explanation for pending catalog proposals cannot be added or verified. Open the PR and state that pending proposals are not grandfathered and must meet the new evidence requirements.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>