### PR TITLE
fix(axi-sdk-js): use absolute path for hooks when CLI installed via a Node version manager

### DIFF
--- a/packages/axi-sdk-js/src/hooks.ts
+++ b/packages/axi-sdk-js/src/hooks.ts
@@ -353,6 +353,31 @@ function installOpenCodeAmbientPlugin(
   }
 }
 
+// Node version managers add their active bin directory to PATH from
+// interactive shell startup files (~/.zshrc, ~/.bashrc, fnm/asdf hooks).
+// Agent SessionStart hooks, however, run under a NON-interactive shell
+// (Claude Code spawns `/bin/sh -c "<command>"`) that never sources those
+// files. A bare binary name that resolves via one of these directories at
+// install time therefore becomes "command not found" when the hook later
+// fires. Detect such directories so the caller falls back to the absolute
+// exec path, which does not depend on PATH.
+const VERSION_MANAGER_PATH_SEGMENTS = new Set([
+  ".nvm", // nvm
+  ".nvs", // nvs
+  ".fnm", // fnm (install / some layouts)
+  "fnm_multishells", // fnm (per-shell PATH entry — the common case)
+  ".asdf", // asdf
+  ".volta", // Volta
+  ".nodenv", // nodenv
+]);
+
+export function isVersionManagerPathEntry(dir: string): boolean {
+  return dir
+    .replaceAll("\\", "/")
+    .split("/")
+    .some((segment) => VERSION_MANAGER_PATH_SEGMENTS.has(segment));
+}
+
 export function resolvePortableHookCommand(
   execPath: string,
   binaryNames: string[],
@@ -374,6 +399,9 @@ export function resolvePortableHookCommand(
     }
     for (const dir of context.pathEntries) {
       if (!dir) continue;
+      // Skip version-manager bin dirs: the bare name resolves here now but
+      // won't be on PATH when the hook runs in a non-interactive shell.
+      if (isVersionManagerPathEntry(dir)) continue;
       for (const ext of context.pathExtensions) {
         const candidate = join(dir, `${name}${ext}`);
         const resolvedCandidate = context.resolveRealPath(candidate);

--- a/packages/axi-sdk-js/test/hooks.test.ts
+++ b/packages/axi-sdk-js/test/hooks.test.ts
@@ -18,6 +18,7 @@ import {
   computeSessionStartHookUpdate,
   extractNpmShimScriptPath,
   installSessionStartHooks,
+  isVersionManagerPathEntry,
   resolvePortableHookCommand,
   shouldInstallHooksForNodeAxiExecPath,
 } from "../src/hooks.js";
@@ -336,6 +337,76 @@ describe("resolvePortableHookCommand", () => {
     expect(
       resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
     ).toBe(exec);
+  });
+
+  it("returns the absolute exec path when the binary only resolves via nvm", () => {
+    // Reproduces the reported bug: `gh-axi setup hooks` run from an
+    // interactive shell where nvm has put its bin dir on PATH. The bare name
+    // resolves now, but the hook later runs under `/bin/sh` without nvm.
+    const exec = "/home/me/.nvm/versions/node/v20.11.1/bin/gh-axi";
+    const context = {
+      pathEntries: ["/home/me/.nvm/versions/node/v20.11.1/bin"],
+      pathExtensions: [""],
+      resolveRealPath: (p: string) =>
+        ({
+          [exec]: exec,
+          "/home/me/.nvm/versions/node/v20.11.1/bin/gh-axi": exec,
+        })[p],
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe(exec);
+  });
+
+  it("prefers a stable PATH dir over a version-manager dir for the same binary", () => {
+    const exec = "/usr/local/lib/node_modules/gh-axi/dist/bin/gh-axi.js";
+    const context = {
+      // nvm dir comes first but must be skipped in favor of /usr/local/bin.
+      pathEntries: [
+        "/home/me/.nvm/versions/node/v20.11.1/bin",
+        "/usr/local/bin",
+      ],
+      pathExtensions: [""],
+      resolveRealPath: (p: string) =>
+        ({
+          [exec]: exec,
+          "/home/me/.nvm/versions/node/v20.11.1/bin/gh-axi": exec,
+          "/usr/local/bin/gh-axi": exec,
+        })[p],
+    };
+
+    expect(
+      resolvePortableHookCommand(exec, ["gh-axi"], "gh-axi", context),
+    ).toBe("gh-axi");
+  });
+});
+
+describe("isVersionManagerPathEntry", () => {
+  it("flags version-manager bin directories", () => {
+    for (const dir of [
+      "/home/me/.nvm/versions/node/v20.11.1/bin",
+      "/home/me/.nvs/node/20.11.1/x64/bin",
+      "/home/me/.fnm/node-versions/v20.11.1/installation/bin",
+      "/home/me/Library/Application Support/fnm_multishells/1234_567/bin",
+      "/home/me/.asdf/shims",
+      "/home/me/.volta/bin",
+      "/home/me/.nodenv/shims",
+    ]) {
+      expect(isVersionManagerPathEntry(dir)).toBe(true);
+    }
+  });
+
+  it("does not flag stable system directories", () => {
+    for (const dir of [
+      "/usr/local/bin",
+      "/opt/homebrew/bin",
+      "/usr/bin",
+      "/home/me/.local/bin",
+      "C:\\Program Files\\nodejs",
+    ]) {
+      expect(isVersionManagerPathEntry(dir)).toBe(false);
+    }
   });
 });
 


### PR DESCRIPTION
## Problem

`<tool> setup hooks` (e.g. `jira-axi setup hooks`, `confluence-axi setup hooks`) registers a Claude Code `SessionStart` hook that fails on every session start with:

```
Failed with non-blocking status code: /bin/sh: jira-axi: command not found
```

...even though `jira-axi` works fine in the user's terminal.

## Root cause

`resolvePortableHookCommand` prefers the **bare binary name** (`jira-axi`) whenever that name resolves on `process.env.PATH` at install time. When the CLI is installed through a Node version manager (nvm, nvs, fnm, asdf, Volta, nodenv), the manager's active `bin` directory is only added to `PATH` by **interactive** shell startup files (`~/.zshrc`, `~/.bashrc`, fnm/asdf shell hooks).

Claude Code runs `SessionStart` hooks under a **non-interactive** shell (`/bin/sh -c "<command>"`) that never sources those files, so the version-manager `bin` dir is absent from `PATH` and the bare name is `command not found`. The install-time PATH ≠ the hook-execution-time PATH.

## Fix

Skip version-manager-managed directories when choosing the hook command. When the bare name only resolves via such a directory, the resolver falls back to the absolute exec path it already computes — which does not depend on an interactively-augmented `PATH`. If the binary is also reachable from a stable system dir (e.g. `/usr/local/bin`), the short portable name is still used.

Detected via path segment match: `.nvm`, `.nvs`, `.fnm`, `fnm_multishells`, `.asdf`, `.volta`, `.nodenv`.

## Tests

- `resolvePortableHookCommand` returns the absolute path when the binary only resolves via an nvm dir (regression for the reported bug).
- A stable PATH dir still wins over a version-manager dir for the same binary.
- Truth table for the new exported `isVersionManagerPathEntry` helper.

`tsc` build, `vitest` (125/125), `prettier --check`, and `eslint` on the changed files all pass.

## Known limitation (out of scope)

If Node itself is reachable *only* via a version manager (no system `node` on the non-interactive PATH), the absolute-script command's `#!/usr/bin/env node` shebang would still fail to find `node`. A fully robust fix would anchor the command on `process.execPath`, but that reintroduces version-pinning trade-offs, so it's left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)