### PR TITLE
fix: execute every PR body compliance event

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -1,4 +1,5 @@
 name: Require no-mistakes
+run-name: "PR #${{ github.event.pull_request.number }} body compliance - ${{ github.event.action }} - event ${{ github.run_number }} (run ${{ github.run_id }})"
 
 on:
   pull_request:
@@ -9,8 +10,12 @@ on:
 permissions:
   contents: read
 
+# GitHub concurrency groups retain at most one pending run, replacing older
+# pending runs even when cancel-in-progress is false. Give body-bearing events
+# an immutable per-event group so first-time-fork approvals can never collapse
+# opened/edited checks. Keep synchronize/reopened coalescing as before.
 concurrency:
-  group: no-mistakes-required-${{ github.event.pull_request.number }}
+  group: no-mistakes-required-${{ github.event.pull_request.number }}-${{ (github.event.action == 'opened' || github.event.action == 'edited') && github.run_id || 'head-change' }}
   cancel-in-progress: true
 
 jobs:

--- a/.no-mistakes/evidence/fm/nm-body-events-axi-r1/live-preimage-runs.txt
+++ b/.no-mistakes/evidence/fm/nm-body-events-axi-r1/live-preimage-runs.txt
@@ -1,0 +1,26 @@
+count: 2
+runs[2]{id,title,status,conclusion,workflow,branch,event,created}:
+  29960499892,"fix(docs): make AXI site responsive on mobile",completed,success,Require no-mistakes,fm/axi-site-responsive-fix-pr,pull_request,8h ago
+  29958898968,"fix(docs): make AXI site responsive on mobile",completed,success,Require no-mistakes,fm/axi-site-responsive-fix-pr,pull_request,9h ago
+help[1]:
+  Run `gh-axi run view <id>` to view details
+run:
+  id: 29958898968
+  title: "fix(docs): make AXI site responsive on mobile"
+  status: completed
+  conclusion: success
+  workflow: Require no-mistakes
+  branch: fm/axi-site-responsive-fix-pr
+  created: 9h ago
+jobs[1]{id,name,status,conclusion}:
+  89054817323,PR must be raised via no-mistakes,completed,success
+run:
+  id: 29960499892
+  title: "fix(docs): make AXI site responsive on mobile"
+  status: completed
+  conclusion: success
+  workflow: Require no-mistakes
+  branch: fm/axi-site-responsive-fix-pr
+  created: 8h ago
+jobs[1]{id,name,status,conclusion}:
+  89060065846,PR must be raised via no-mistakes,completed,success

--- a/.no-mistakes/evidence/fm/nm-body-events-axi-r1/workflow-policy-e2e.txt
+++ b/.no-mistakes/evidence/fm/nm-body-events-axi-r1/workflow-policy-e2e.txt
@@ -1,0 +1,20 @@
+YAML syntax parse: PASS
+Workflow policy E2E replay: PASS
+Authorized scope: PASS (exact two-hunk normalization equals base)
+Preservation: pull_request, contents:read, no checkout/secrets/write, stable check name, marker, and bot exemptions
+
+opened      exit=0 group=no-mistakes-required-123-900001
+  run-name: PR #123 body compliance - opened - event 410 (run 900001)
+  user-visible: Found no-mistakes signature in PR #123 body.
+edited      exit=1 group=no-mistakes-required-123-900002
+  run-name: PR #123 body compliance - edited - event 411 (run 900002)
+  user-visible: ::error::This PR was not raised through no-mistakes.
+edited      exit=0 group=no-mistakes-required-123-900003
+  run-name: PR #123 body compliance - edited - event 412 (run 900003)
+  user-visible: Found no-mistakes signature in PR #123 body.
+synchronize exit=0 group=no-mistakes-required-123-head-change
+  run-name: PR #123 body compliance - synchronize - event 413 (run 900004)
+  user-visible: Found no-mistakes signature in PR #123 body.
+reopened    exit=0 group=no-mistakes-required-123-head-change
+  run-name: PR #123 body compliance - reopened - event 414 (run 900005)
+  user-visible: Found no-mistakes signature in PR #123 body.


### PR DESCRIPTION
## Intent

Implement the captain-authorized, repository-specific rollout of the merged kunchenguid/no-mistakes#558 PR-body compliance-event policy in axi. Apply only the exact two-hunk change to .github/workflows/no-mistakes-required.yml: add the canonical run-name and give opened/edited events immutable run-id concurrency groups while synchronize/reopened retain the shared head-change group and cancel-in-progress remains true. Preserve pull_request rather than pull_request_target, contents: read with no writes, no secrets/checkout/fork-code execution, the stable check name, signature marker, bot exemptions, and all unrelated prose and behavior. Verify the live pre-image variant, deterministic signed/unsigned/signed replay, run identities and monotonic names, syntax/lint, preservation assertions, and relevant repository suites. Ship one PR titled 'fix: execute every PR body compliance event', stop when CI is green, and do not merge or edit unrelated documentation.

## What Changed

- Add descriptive workflow run names and immutable concurrency groups for `opened` and `edited` PR events, while retaining shared `head-change` coalescing for `synchronize` and `reopened` events.
- Add evidence capturing the live pre-change runs and deterministic workflow-policy replay, including syntax and preservation checks.

## Risk Assessment

✅ Low: The change exactly matches the canonical two-hunk workflow update from merged no-mistakes PR #558, uniquely groups opened/edited events by run ID, preserves shared head-change grouping for synchronize/reopened, and leaves all required security and compliance behavior unchanged.

## Testing

Live pre-image runs confirmed the former generic run titles and stable check name; strict YAML parsing passed, and deterministic signed/unsigned/signed replay demonstrated unique immutable opened/edited groups, shared synchronize/reopened grouping, monotonic canonical run names, and unchanged compliance outcomes. The initially attempted local `yaml` dependency was absent, so the available system YAML parser was used successfully. No unrelated repository suite or prohibited linter was run because this workflow-only change has no focused repository test target.

- Evidence: [Deterministic workflow policy replay](https://github.com/kunchenguid/axi/blob/76b9bfd355c7a817cf384f2e134287d794f053a1/.no-mistakes/evidence/fm/nm-body-events-axi-r1/workflow-policy-e2e.txt)
- Evidence: [Live pre-image workflow runs](https://github.com/kunchenguid/axi/blob/76b9bfd355c7a817cf384f2e134287d794f053a1/.no-mistakes/evidence/fm/nm-body-events-axi-r1/live-preimage-runs.txt)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=80 e5f198e5d34d0d08442c3e9df0b055ecc06e968a af6c70f5a559b5dfafc76abf6631d2e165891fb2 -- .github/workflows/no-mistakes-required.yml`
- <code>`gh-axi run list --workflow no-mistakes-required.yml --branch fm/axi-site-responsive-fix-pr --limit 10` and `gh-axi run view` for runs `29958898968` and `29960499892`</code>
- `ruby -e 'require "yaml"; YAML.parse_file(ARGV.fetch(0))' .github/workflows/no-mistakes-required.yml`
- `Focused Node replay of the workflow shell step for signed opened, unsigned edited, signed edited, synchronize, and reopened events`
- <code>Exact base-to-target normalization plus assertions preserving `pull_request`, `contents: read`, stable check name, signature marker, bot exemptions, and absence of checkout, secrets, or write permissions</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
