### PR TITLE
docs: add axi-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AXIs built and maintained by the community:
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 | [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
+| [`axi-axi`](https://github.com/CodyEngel/axi-axi)                                                  | CodyEngel          | AXI authoring         | Scaffold a compliant AXI, read the 10 principles in token-tuned slices, and run read-only compliance checks against a candidate CLI.                         |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -151,3 +151,8 @@ community:
     author: karotkriss
     domain: GitLab
     description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."
+  - name: axi-axi
+    url: https://github.com/CodyEngel/axi-axi
+    author: CodyEngel
+    domain: AXI authoring
+    description: "Scaffold a compliant AXI, read the 10 principles in token-tuned slices, and run read-only compliance checks against a candidate CLI."

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,6 +711,20 @@
                     glab CLI with agent-ergonomic TOON output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/CodyEngel/axi-axi"
+                      ><code>axi-axi</code></a
+                    >
+                  </td>
+                  <td>CodyEngel</td>
+                  <td>AXI authoring</td>
+                  <td>
+                    Scaffold a compliant AXI, read the 10 principles in
+                    token-tuned slices, and run read-only compliance checks
+                    against a candidate CLI.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

Add the axi-axi package (https://github.com/CodyEngel/axi-axi) to the AXI community catalog so it shows up in the generated README.md and axi.md catalog tables.

## What Changed

- Added an `axi-axi` entry (author `CodyEngel`, domain "AXI authoring") to the `community` section of `catalog.yaml`, the single source for the AXI catalog.
- Regenerated the `generated:catalog-community` regions of `README.md` and `docs/index.html` so the new row appears in both the README table and the axi.md site table.

## Risk Assessment

✅ Low: A three-file, docs-only catalog addition that follows the documented contributor workflow exactly, with generated regions consistent with what the generator would emit and no source-verifiable defects.

## Testing

I exercised the catalog change on all three surfaces it touches. The docs:check CI gate passes, meaning the committed README.md and docs/index.html tables are byte-exact regenerations of catalog.yaml; a negative test (dropping the axi-axi entry) made that same check fail on both files, proving the rows are genuinely generated from the new entry rather than hand-typed, and the worktree was left clean after restoring. I then served docs/ locally and screenshotted the real axi.md page, showing axi-axi as the final community-catalog row with the correct author, domain, description, and a link to github.com/CodyEngel/axi-axi (which returns HTTP 200). README.md has no rendered screenshot because its end-user surface is GitHub's own markdown renderer, which isn't reproducible offline without sending content to an external API; the identical catalog data is shown rendered in the axi.md screenshots, and the README row is verified through its generated table region plus the byte-exact docs:check gate. Everything passed with no issues found.

- Evidence: axi.md community catalog — full table with axi-axi as the last row (rendered site) (local file: <code>/var/folders/h0/hd2bmc2524z2fz14zcl1p4400000gn/T/no-mistakes-evidence/01KY8K1RATY258V0NX239V9WWG/axi-md-community-table-full.png</code>)
- Evidence: axi.md community catalog — close-up of the axi-axi row at full reading size (local file: <code>/var/folders/h0/hd2bmc2524z2fz14zcl1p4400000gn/T/no-mistakes-evidence/01KY8K1RATY258V0NX239V9WWG/axi-md-community-catalog.png</code>)
- Evidence: axi.md catalog section — COMMUNITY heading and column headers in context (local file: <code>/var/folders/h0/hd2bmc2524z2fz14zcl1p4400000gn/T/no-mistakes-evidence/01KY8K1RATY258V0NX239V9WWG/axi-md-catalog-full-table.png</code>)
<details>
<summary>Evidence: docs:check gate, drift negative test, generated README row, and link reachability</summary>

<code>$ pnpm run docs:check&#10;docs:check ok — generated regions match their sources&#10;&#10;# --- Negative test: temporarily drop the axi-axi entry from catalog.yaml ---&#10;error: README.md is out of sync with catalog.yaml/principles.yaml&#10;error: docs/index.html is out of sync with catalog.yaml/principles.yaml&#10;exit code 1 -&gt; both tables really are generated from the catalog entry (restored afterwards; git status clean)&#10;&#10;# --- README.md community catalog table (generated region) ---&#10;| [`axi-axi`](https://github.com/CodyEngel/axi-axi) | CodyEngel | AXI authoring | Scaffold a compliant AXI, read the 10 principles in token-tuned slices, and run read-only compliance checks against a candidate CLI. |&#10;&#10;# --- catalog link reachability ---&#10;GET https://github.com/CodyEngel/axi-axi -&gt; HTTP 200</code>

```text
$ pnpm run docs:check       # the docs-check CI gate: regenerates from catalog.yaml and fails on drift
docs:check ok — generated regions match their sources

# --- Negative test: temporarily drop the axi-axi entry from catalog.yaml ---
$ node scripts/generate-docs.mjs --check   (with axi-axi removed from catalog.yaml)
error: README.md is out of sync with catalog.yaml/principles.yaml
error: docs/index.html is out of sync with catalog.yaml/principles.yaml
help: run `pnpm run docs:gen` and commit the result
exit code 1   -> both tables really are generated from the catalog entry (catalog.yaml restored afterwards; git status clean)

# --- README.md community catalog table, last rows as a reader sees them ---
| AXI                                                                                                | Author             | Domain                | What it does                                                                                                                                                 |
| -------------------------------------------------------------------------------------------------- | ------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
| [`axi-axi`](https://github.com/CodyEngel/axi-axi)                                                  | CodyEngel          | AXI authoring         | Scaffold a compliant AXI, read the 10 principles in token-tuned slices, and run read-only compliance checks against a candidate CLI.                         |


# --- catalog link reachability ---
GET https://github.com/CodyEngel/axi-axi -> HTTP 200
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `catalog.yaml:154` - VISION.md&#39;s catalog policy requires an independent maintainer source review of the package at an exact pinned revision or release before a positive admission verdict, and names existence checks and contributor-provided claims as insufficient evidence. This diff review verified only that the entry is well-formed, the repo exists and is public, and the catalog text matches the package&#39;s own README — that does not satisfy the policy. No change to the diff is needed; the pinned-source review is maintainer-owned.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --frozen-lockfile` (workspace deps for the docs generator)</code>
- <code>`pnpm run docs:check` — the docs-check CI gate; regenerates README.md + docs/index.html regions from catalog.yaml and fails on drift (passed)</code>
- <code>Negative test: temporarily removed the `axi-axi` entry from catalog.yaml and re-ran `node scripts/generate-docs.mjs --check` — failed with drift on both README.md and docs/index.html (exit 1), then restored catalog.yaml and re-ran the check (passed, `git status` clean)</code>
- <code>`pnpm run docs:test` (`node --test scripts/generate-docs.test.mjs`) — generator escaping/link/pipe helpers</code>
- <code>Manual render: served `docs/` at http://127.0.0.1:8731 and loaded index.html in Chrome; asserted the rendered row cells and link href via DOM read, then captured screenshots of the community catalog table</code>
- <code>`curl -L https://github.com/CodyEngel/axi-axi` — catalog link resolves (HTTP 200)</code>
- <code>Inspected the generated `generated:catalog-community` region of README.md to confirm the axi-axi row is present in the committed markdown table</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
