### PR TITLE
fix(axi-sdk-js): route initialize and resolveContext failures through the AXI error contract

### DIFF
--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -40,7 +40,7 @@ export interface AxiCliOptions<TContext = undefined> {
   commands: Record<string, AxiCliCommand<TContext>>;
   home: AxiCliCommand<TContext>;
   getCommandHelp?: (command: string) => string | null | undefined;
-  initialize?: () => void;
+  initialize?: () => MaybePromise<void>;
   resolveContext?: (input: AxiResolveContextInput) => MaybePromise<TContext>;
   stdout?: { write: (chunk: string) => unknown };
   renderUnknownCommand?: (command: string) => string;
@@ -77,7 +77,7 @@ export async function runAxiCli<TContext = undefined>(
   const stdout = options.stdout ?? process.stdout;
 
   try {
-    options.initialize?.();
+    await options.initialize?.();
   } catch (error) {
     writeFormattedError(error, stdout, options);
     return;

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -169,6 +169,9 @@ async function runHandler<TContext>(
   isHomeView: boolean,
 ): Promise<void> {
   try {
+    // Context resolution stays inside this boundary so a failing `resolveContext`
+    // reports through the same structured-error contract as the handler itself,
+    // and still only runs for views that actually need a context.
     const context = await options.resolveContext?.(contextInput);
     const output = await handler(args, context);
     stdout.write(`${renderCommandOutput(output, options, isHomeView)}\n`);

--- a/packages/axi-sdk-js/src/cli.ts
+++ b/packages/axi-sdk-js/src/cli.ts
@@ -74,9 +74,15 @@ function defaultUnknownCommand(command: string): string {
 export async function runAxiCli<TContext = undefined>(
   options: AxiCliOptions<TContext>,
 ): Promise<void> {
-  options.initialize?.();
-
   const stdout = options.stdout ?? process.stdout;
+
+  try {
+    options.initialize?.();
+  } catch (error) {
+    writeFormattedError(error, stdout, options);
+    return;
+  }
+
   const argv = options.argv ?? process.argv.slice(2);
 
   if (argv.length === 1 && argv[0] === "--help") {
@@ -108,11 +114,14 @@ export async function runAxiCli<TContext = undefined>(
 
   const command = argv[0];
   if (!command) {
-    const context = await options.resolveContext?.({
-      command: undefined,
-      args: [],
-    });
-    await runHandler(options.home, [], context, stdout, options, true);
+    await runHandler(
+      options.home,
+      [],
+      { command: undefined, args: [] },
+      stdout,
+      options,
+      true,
+    );
     return;
   }
 
@@ -148,25 +157,23 @@ export async function runAxiCli<TContext = undefined>(
     return;
   }
 
-  const context = await options.resolveContext?.({ command, args });
-  await runHandler(handler, args, context, stdout, options, false);
+  await runHandler(handler, args, { command, args }, stdout, options, false);
 }
 
 async function runHandler<TContext>(
   handler: AxiCliCommand<TContext>,
   args: string[],
-  context: TContext | undefined,
+  contextInput: AxiResolveContextInput,
   stdout: { write: (chunk: string) => unknown },
   options: AxiCliOptions<TContext>,
   isHomeView: boolean,
 ): Promise<void> {
   try {
+    const context = await options.resolveContext?.(contextInput);
     const output = await handler(args, context);
     stdout.write(`${renderCommandOutput(output, options, isHomeView)}\n`);
   } catch (error) {
-    const formatted = (options.formatError ?? defaultFormatError)(error);
-    stdout.write(formatted.output);
-    process.exitCode = formatted.exitCode;
+    writeFormattedError(error, stdout, options);
   }
 }
 
@@ -189,10 +196,18 @@ async function runBuiltinUpdate<TContext>(
     });
     stdout.write(`${renderOutput(output)}\n`);
   } catch (error) {
-    const formatted = (options.formatError ?? defaultFormatError)(error);
-    stdout.write(formatted.output);
-    process.exitCode = formatted.exitCode;
+    writeFormattedError(error, stdout, options);
   }
+}
+
+function writeFormattedError<TContext>(
+  error: unknown,
+  stdout: { write: (chunk: string) => unknown },
+  options: AxiCliOptions<TContext>,
+): void {
+  const formatted = (options.formatError ?? defaultFormatError)(error);
+  stdout.write(formatted.output);
+  process.exitCode = formatted.exitCode;
 }
 
 function resolveBinName(): string {

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -38,7 +38,7 @@ import { AxiError } from "../src/errors.js";
 const execFileAsync = promisify(execFile);
 
 async function runErrorBoundaryFixture(
-  phase: "initialize" | "resolveContext",
+  phase: "initialize" | "initialize-async" | "resolveContext",
   errorKind: "axi" | "generic",
   view: "home" | "command",
 ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
@@ -492,6 +492,19 @@ describe("runAxiCli subprocess integration", () => {
     async ({ errorKind, exitCode, stdout }) => {
       const result = await runErrorBoundaryFixture(
         "initialize",
+        errorKind,
+        "home",
+      );
+
+      expect(result).toEqual({ exitCode, stdout, stderr: "" });
+    },
+  );
+
+  it.each(failureCases)(
+    "formats $errorKind asynchronous initialize rejections on stdout",
+    async ({ errorKind, exitCode, stdout }) => {
+      const result = await runErrorBoundaryFixture(
+        "initialize-async",
         errorKind,
         "home",
       );

--- a/packages/axi-sdk-js/test/cli.test.ts
+++ b/packages/axi-sdk-js/test/cli.test.ts
@@ -37,6 +37,39 @@ import { AxiError } from "../src/errors.js";
 
 const execFileAsync = promisify(execFile);
 
+async function runErrorBoundaryFixture(
+  phase: "initialize" | "resolveContext",
+  errorKind: "axi" | "generic",
+  view: "home" | "command",
+): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/error-boundary-bin.mjs", import.meta.url),
+  );
+  const viteNodePath = fileURLToPath(
+    new URL("../node_modules/.bin/vite-node", import.meta.url),
+  );
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      viteNodePath,
+      [fixturePath, phase, errorKind, view],
+      { cwd: new URL("..", import.meta.url) },
+    );
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const result = error as Error & {
+      code: number;
+      stdout: string;
+      stderr: string;
+    };
+    return {
+      exitCode: result.code,
+      stdout: result.stdout,
+      stderr: result.stderr,
+    };
+  }
+}
+
 describe("runAxiCli", () => {
   const originalArgv = [...process.argv];
   const stdout = { write: vi.fn(() => true) };
@@ -440,6 +473,59 @@ describe("runAxiCli", () => {
 });
 
 describe("runAxiCli subprocess integration", () => {
+  const failureCases = [
+    {
+      errorKind: "axi" as const,
+      exitCode: 2,
+      stdout:
+        "error: Invalid fixture request\ncode: VALIDATION_ERROR\nhelp[1]: Run `fixture --help`\n",
+    },
+    {
+      errorKind: "generic" as const,
+      exitCode: 1,
+      stdout: "error: Dependency exploded\ncode: UNKNOWN\n",
+    },
+  ];
+
+  it.each(failureCases)(
+    "formats $errorKind initialize failures on stdout",
+    async ({ errorKind, exitCode, stdout }) => {
+      const result = await runErrorBoundaryFixture(
+        "initialize",
+        errorKind,
+        "home",
+      );
+
+      expect(result).toEqual({ exitCode, stdout, stderr: "" });
+    },
+  );
+
+  it.each(failureCases)(
+    "formats $errorKind resolveContext failures for home on stdout",
+    async ({ errorKind, exitCode, stdout }) => {
+      const result = await runErrorBoundaryFixture(
+        "resolveContext",
+        errorKind,
+        "home",
+      );
+
+      expect(result).toEqual({ exitCode, stdout, stderr: "" });
+    },
+  );
+
+  it.each(failureCases)(
+    "formats $errorKind resolveContext failures for commands on stdout",
+    async ({ errorKind, exitCode, stdout }) => {
+      const result = await runErrorBoundaryFixture(
+        "resolveContext",
+        errorKind,
+        "command",
+      );
+
+      expect(result).toEqual({ exitCode, stdout, stderr: "" });
+    },
+  );
+
   it.each(["--version", "-v", "-V"])(
     "prints version from a real entrypoint for bare %s",
     async (flag) => {

--- a/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs
+++ b/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs
@@ -1,0 +1,35 @@
+import { AxiError, runAxiCli } from "../../src/index.ts";
+
+const [phase, errorKind, view] = process.argv.slice(2);
+
+function fixtureError() {
+  if (errorKind === "axi") {
+    return new AxiError("Invalid fixture request", "VALIDATION_ERROR", [
+      "Run `fixture --help`",
+    ]);
+  }
+
+  return new Error("Dependency exploded");
+}
+
+await runAxiCli({
+  description: "Fixture CLI",
+  argv: view === "command" ? ["issue", "list"] : [],
+  topLevelHelp: "fixture help",
+  initialize:
+    phase === "initialize"
+      ? () => {
+          throw fixtureError();
+        }
+      : undefined,
+  resolveContext:
+    phase === "resolveContext"
+      ? async () => {
+          throw fixtureError();
+        }
+      : undefined,
+  home: async () => ({ home: "ok" }),
+  commands: {
+    issue: async () => ({ issues: [] }),
+  },
+});

--- a/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs
+++ b/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs
@@ -21,7 +21,11 @@ await runAxiCli({
       ? () => {
           throw fixtureError();
         }
-      : undefined,
+      : phase === "initialize-async"
+        ? async () => {
+            throw fixtureError();
+          }
+        : undefined,
   resolveContext:
     phase === "resolveContext"
       ? async () => {


### PR DESCRIPTION
## Intent

Corrigir upstream o limite de tratamento de erros de axi-sdk-js identificado e reproduzido na investigação em /Users/nathanbennesby/firstmate/data/axi-opportunities-scout-a1/report.md. Falhas de initialize() e resolveContext() devem seguir o contrato público do handler: saída AXI estruturada em stdout, stderr vazio para erros de domínio e exit code apropriado. AxiError deve preservar código, mensagem e sugestões; erros desconhecidos devem ser normalizados como UNKNOWN sem stack trace exposto. Ajuda, versão, home, comando desconhecido, contexto lazy e precedência de handler não podem regredir. A investigação deve reproduzir primeiro pelo executável real usando o build atual, registrar trigger, condição e sintoma, comparar initialize e resolveContext com o handler, e inspecionar histórico e testes procurando inclusive evidência que refute a causa. Os testes de regressão devem começar vermelhos para initialize, resolveContext no home e resolveContext em comando, cobrindo AxiError e erro genérico, stdout, stderr e exit status pelo contrato público ou subprocesso. Fazer a menor mudança coerente que coloque essas fases sob o limite correto, sem duplicar formatadores nem esconder erros de programação além do contrato existente. Atualizar documentação somente se o comportamento público documentado realmente mudar; não editar CHANGELOG.md, arquivos gerados, benchmarks, hooks, update ou divergências documentais alheias. Executar build, formato, lint, testes do SDK e checks relevantes do repositório. A entrega local não basta: executar o pipeline no-mistakes completo a partir do commit, tratar seus retornos pela própria pipeline, abrir PR upstream, aguardar checks verdes e nunca fazer merge.

## What Changed

- `runAxiCli()` now awaits `options.initialize?.()` inside an error boundary and moves `resolveContext` into `runHandler`, so failures in either phase emit structured AXI output on stdout with the mapped exit code instead of an unhandled rejection and raw stack trace. `initialize` is widened to `() => MaybePromise<void>`, and context is still resolved only for the home view and real commands, so `--help`, `--version` and unknown commands stay lazy.
- Error formatting is consolidated into a single `writeFormattedError()` helper shared by the handler path and the built-in `update` path; `formatError` precedence and the existing `AxiError` code/message/suggestion mapping are unchanged.
- Added subprocess regression coverage (`test/cli.test.ts` plus a new `test/fixtures/error-boundary-bin.mjs`) asserting stdout, stderr and exit status for `initialize` (sync and async) and `resolveContext` failures on both the home view and a command, for `AxiError` and generic errors.

Note for consumers: `initialize`/`resolveContext` rejections no longer propagate out of `runAxiCli()`, so a tool wrapping the call in its own try/catch will no longer see them for those phases — they are formatted by the SDK, still overridable via `formatError`.

## Risk Assessment

✅ Low: The change is a small, well-bounded error-boundary fix confined to one SDK file plus new tests, it preserves every lazy-context and dispatch-precedence invariant the intent marks as non-regressable, and it is covered by public-contract subprocess tests asserting stdout, stderr, and exit code together.

## Testing

I installed deps, built the SDK, and ran the targeted `test/cli.test.ts` suite plus the small axi-sdk-js package suite (all green), then proved the intent at product level: a real `demo-axi` executable built on the compiled dist shows initialize() and resolveContext() failures now rendering structured AXI errors on stdout with empty stderr and correct exit codes (AxiError keeps code/message/suggestions, VALIDATION_ERROR maps to 2, plain errors normalize to UNKNOWN with no stack), whereas the same transcript against a dist rebuilt from the base commit reproduces the reported stack-trace-on-stderr/empty-stdout defect. The new regression tests were confirmed to start red on the base cli.ts and green on the fix, and help, version, home, command dispatch, unknown command, leading-flag error, lazy context and built-in-update precedence all behave unchanged through the real binary. Build output was removed afterwards and the worktree is clean.

<details>
<summary>Evidence: Before/after comparison of the real CLI (stdout, stderr, exit) for all four failure phases</summary>

<code>$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi issue list&#10;&#10;BEFORE (93c5f33) AFTER (98b0072)&#10;stdout: &lt;empty&gt; stdout: error: Not authenticated to demo service&#10;code: AUTH_ERROR&#10;help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment&#10;stderr: AxiError stack… stderr: &lt;empty&gt;&#10;exit: 1 exit: 1&#10;&#10;$ DEMO_FAIL=initialize DEMO_ERROR=generic demo-axi&#10;&#10;BEFORE: stdout &lt;empty&gt;, stderr &#34;Error: socket hang up&#34; + stack, exit 1&#10;AFTER: stdout &#34;error: socket hang up / code: UNKNOWN&#34;, stderr &lt;empty&gt;, exit 1</code>

```text
# axi-sdk-js error boundary: real CLI, before vs after

`demo-axi` is a real executable built on the freshly compiled `packages/axi-sdk-js/dist`.
`DEMO_FAIL` picks the phase that throws; `DEMO_ERROR=axi` throws an `AxiError`, `generic` a plain `Error`.

## `$ DEMO_FAIL=initialize DEMO_ERROR=axi demo-axi`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: Not authenticated to demo service<br>code: AUTH_ERROR<br>help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## `$ DEMO_FAIL=initialize DEMO_ERROR=generic demo-axi`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: socket hang up<br>code: UNKNOWN</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## `$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: Not authenticated to demo service<br>code: AUTH_ERROR<br>help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## `$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: socket hang up<br>code: UNKNOWN</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## `$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi issue list`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: Not authenticated to demo service<br>code: AUTH_ERROR<br>help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## `$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi issue list`

| | before (93c5f33) | after (98b0072) |
| --- | --- | --- |
| stdout | `<empty>` | <pre>error: socket hang up<br>code: UNKNOWN</pre> |
| stderr | stack trace (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000g …) | `<empty>` |
| exit | 1 | 1 |

## Reproducing

`` `sh
pnpm install --filter axi-sdk-js...
pnpm --dir packages/axi-sdk-js run build     # demo-axi imports the compiled dist/
bash <evidence-dir>/transcript.sh            # full CLI transcript (all surfaces)
pnpm --dir packages/axi-sdk-js exec vitest run test/cli.test.ts
`` `

The "before" column was produced by `git checkout 93c5f33 -- packages/axi-sdk-js/src/cli.ts`,
rebuilding, rerunning the same transcript, then restoring the file (worktree verified clean afterwards).
```
</details>
<details>
<summary>Evidence: Full CLI transcript with the fix (failure phases + non-regression surfaces + lazy context)</summary>

```text
############ FAILURE PHASES (the reported defect) ############

==============================================================
$ DEMO_FAIL=initialize DEMO_ERROR=axi demo-axi 
--- stdout ---
error: Not authenticated to demo service
code: AUTH_ERROR
help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=initialize DEMO_ERROR=generic demo-axi 
--- stdout ---
error: socket hang up
code: UNKNOWN
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi 
--- stdout ---
error: Not authenticated to demo service
code: AUTH_ERROR
help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi 
--- stdout ---
error: socket hang up
code: UNKNOWN
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi issue list
--- stdout ---
error: Not authenticated to demo service
code: AUTH_ERROR
help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi issue list
--- stdout ---
error: socket hang up
code: UNKNOWN
--- stderr ---
<empty>
--- exit code: 1

==============================================================
$ DEMO_FAIL=none DEMO_ERROR=axi demo-axi boom
--- stdout ---
error: Not authenticated to demo service
code: AUTH_ERROR
help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment
--- stderr ---
<empty>
--- exit code: 1

############ SURFACES THAT MUST NOT REGRESS ############

==============================================================
$ DEMO_FAIL=none demo-axi 
--- stdout ---
bin: /var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi
description: Demo agent-ergonomic CLI for the error-boundary evidence run
repo: kunchenguid/axi
issues: 3
"help[1]"[1]: Run `demo-axi issue list`
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi issue list
--- stdout ---
repo: kunchenguid/axi
issues[2]{number,title,state}:
  121,New community AXI,open
  117,bench grading hints,open
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi --help
--- stdout ---
bin: demo-axi
help[1]:
  Run `demo-axi issue list`
"built-in":
  update: Upgrade `demo-axi` to the latest published version
  "update --check": Report current vs latest without installing
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi --version
--- stdout ---
1.2.3
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi nope
--- stdout ---
error: "Unknown command: nope"
code: VALIDATION_ERROR
help[1]: Run `--help` to see available commands
--- stderr ---
<empty>
--- exit code: 2

==============================================================
$ DEMO_FAIL=none demo-axi --oops
--- stdout ---
error: Flags must come after the command
code: VALIDATION_ERROR
help[2]: "Run `demo-axi <command> [args] [flags]`",Move `--oops` after the command instead of before it
--- stderr ---
<empty>
--- exit code: 2

############ LAZY CONTEXT: help/version/unknown must not resolve context ############
(resolveContext is rigged to throw; a clean help/version/unknown proves it never ran)

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi --help
--- stdout ---
bin: demo-axi
help[1]:
  Run `demo-axi issue list`
"built-in":
  update: Upgrade `demo-axi` to the latest published version
  "update --check": Report current vs latest without installing
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi --version
--- stdout ---
1.2.3
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi nope
--- stdout ---
error: "Unknown command: nope"
code: VALIDATION_ERROR
help[1]: Run `--help` to see available commands
--- stderr ---
<empty>
--- exit code: 2
```
</details>
<details>
<summary>Evidence: Same transcript against the pre-fix build — reproduces the reported defect</summary>

```text
############ FAILURE PHASES (the reported defect) ############

==============================================================
$ DEMO_FAIL=initialize DEMO_ERROR=axi demo-axi 
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11
    return new AxiError("Not authenticated to demo service", "AUTH_ERROR", [
           ^

AxiError: Not authenticated to demo service
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11:12)
--- exit code: 1

==============================================================
$ DEMO_FAIL=initialize DEMO_ERROR=generic demo-axi 
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16
  return new Error("socket hang up");
         ^

Error: socket hang up
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16:10)
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi 
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11
    return new AxiError("Not authenticated to demo service", "AUTH_ERROR", [
           ^

AxiError: Not authenticated to demo service
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11:12)
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi 
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16
  return new Error("socket hang up");
         ^

Error: socket hang up
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16:10)
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi issue list
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11
    return new AxiError("Not authenticated to demo service", "AUTH_ERROR", [
           ^

AxiError: Not authenticated to demo service
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:11:12)
--- exit code: 1

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=generic demo-axi issue list
--- stdout ---
<empty>
--- stderr ---
file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16
  return new Error("socket hang up");
         ^

Error: socket hang up
    at boom (file:///private/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi:16:10)
--- exit code: 1

==============================================================
$ DEMO_FAIL=none DEMO_ERROR=axi demo-axi boom
--- stdout ---
error: Not authenticated to demo service
code: AUTH_ERROR
help[2]: Run `demo-axi auth login`,Set DEMO_TOKEN in the environment
--- stderr ---
<empty>
--- exit code: 1

############ SURFACES THAT MUST NOT REGRESS ############

==============================================================
$ DEMO_FAIL=none demo-axi 
--- stdout ---
bin: /var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi
description: Demo agent-ergonomic CLI for the error-boundary evidence run
repo: kunchenguid/axi
issues: 3
"help[1]"[1]: Run `demo-axi issue list`
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi issue list
--- stdout ---
repo: kunchenguid/axi
issues[2]{number,title,state}:
  121,New community AXI,open
  117,bench grading hints,open
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi --help
--- stdout ---
bin: demo-axi
help[1]:
  Run `demo-axi issue list`
"built-in":
  update: Upgrade `demo-axi` to the latest published version
  "update --check": Report current vs latest without installing
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi --version
--- stdout ---
1.2.3
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=none demo-axi nope
--- stdout ---
error: "Unknown command: nope"
code: VALIDATION_ERROR
help[1]: Run `--help` to see available commands
--- stderr ---
<empty>
--- exit code: 2

==============================================================
$ DEMO_FAIL=none demo-axi --oops
--- stdout ---
error: Flags must come after the command
code: VALIDATION_ERROR
help[2]: "Run `demo-axi <command> [args] [flags]`",Move `--oops` after the command instead of before it
--- stderr ---
<empty>
--- exit code: 2

############ LAZY CONTEXT: help/version/unknown must not resolve context ############
(resolveContext is rigged to throw; a clean help/version/unknown proves it never ran)

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi --help
--- stdout ---
bin: demo-axi
help[1]:
  Run `demo-axi issue list`
"built-in":
  update: Upgrade `demo-axi` to the latest published version
  "update --check": Report current vs latest without installing
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi --version
--- stdout ---
1.2.3
--- stderr ---
<empty>
--- exit code: 0

==============================================================
$ DEMO_FAIL=resolveContext DEMO_ERROR=axi demo-axi nope
--- stdout ---
error: "Unknown command: nope"
code: VALIDATION_ERROR
help[1]: Run `--help` to see available commands
--- stderr ---
<empty>
--- exit code: 2
```
</details>
<details>
<summary>Evidence: VALIDATION_ERROR from initialize/resolveContext exits 2 with empty stderr (real binary)</summary>

<code>$ DEMO_FAIL=resolveContext DEMO_ERROR=validation demo-axi issue list&#10;error: Missing --repo flag&#10;code: VALIDATION_ERROR&#10;help[1]: Run `demo-axi issue list --repo owner/name`&#10;stderr: &lt;empty&gt;&#10;exit: 2</code>

```text
$ DEMO_FAIL=initialize DEMO_ERROR=validation demo-axi 
error: Missing --repo flag
code: VALIDATION_ERROR
help[1]: Run `demo-axi issue list --repo owner/name`
stderr: <empty>
exit: 2

$ DEMO_FAIL=initialize DEMO_ERROR=validation demo-axi issue list
error: Missing --repo flag
code: VALIDATION_ERROR
help[1]: Run `demo-axi issue list --repo owner/name`
stderr: <empty>
exit: 2

$ DEMO_FAIL=resolveContext DEMO_ERROR=validation demo-axi 
error: Missing --repo flag
code: VALIDATION_ERROR
help[1]: Run `demo-axi issue list --repo owner/name`
stderr: <empty>
exit: 2

$ DEMO_FAIL=resolveContext DEMO_ERROR=validation demo-axi issue list
error: Missing --repo flag
code: VALIDATION_ERROR
help[1]: Run `demo-axi issue list --repo owner/name`
stderr: <empty>
exit: 2
```
</details>
<details>
<summary>Evidence: Regression tests start red on the base cli.ts (only the 8 new cases fail)</summary>

<code>× formats &#39;axi&#39; initialize failures on stdout&#10;× formats &#39;generic&#39; initialize failures on stdout&#10;× formats &#39;axi&#39; asynchronous initialize rejections on stdout&#10;× formats &#39;generic&#39; asynchronous initialize rejections on stdout&#10;× formats &#39;axi&#39; resolveContext failures for home on stdout&#10;× formats &#39;generic&#39; resolveContext failures for home on stdout&#10;× formats &#39;axi&#39; resolveContext failures for commands on stdout&#10;× formats &#39;generic&#39; resolveContext failures for commands on stdout&#10;Tests 8 failed | 24 passed (32)</code>

```text

 RUN  v3.2.4 /Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js

 ❯ test/cli.test.ts (32 tests | 8 failed) 2195ms
   ✓ runAxiCli > runs initializer before dispatch 1ms
   ✓ runAxiCli > shows top-level help for bare --help without resolving context 1ms
   ✓ runAxiCli > shows version for bare --version without resolving context 0ms
   ✓ runAxiCli > shows version for bare -v without resolving context 0ms
   ✓ runAxiCli > shows version for bare -V without resolving context 0ms
   ✓ runAxiCli > uses explicit argv when provided instead of process.argv 0ms
   ✓ runAxiCli > routes command help through getCommandHelp without resolving context 0ms
   ✓ runAxiCli > writes a structured error when flags appear before the command 0ms
   ✓ runAxiCli > writes structured unknown-command errors without resolving context 0ms
   ✓ runAxiCli > routes to the matching command handler with lazy context resolution 0ms
   ✓ runAxiCli > serializes structured handler output at the boundary 0ms
   ✓ runAxiCli > adds bin and description to the home view automatically 0ms
   ✓ runAxiCli > resolves home context only when the home handler actually runs 0ms
   ✓ runAxiCli > does not install hooks automatically from the executable path 0ms
   ✓ runAxiCli > does not auto-install hooks from test worker entrypoints 0ms
   ✓ runAxiCli > handles the built-in update command via runUpdate 1ms
   ✓ runAxiCli > defers to a tool's own update command when registered 0ms
   ✓ runAxiCli > shows built-in update help without running the upgrade 0ms
   ✓ runAxiCli > advertises the built-in update command in bare --help 0ms
   ✓ runAxiCli > does not advertise the built-in update when a tool overrides it 0ms
   ✓ runAxiCli > maps validation errors to exit code 2 0ms
   × runAxiCli subprocess integration > formats 'axi' initialize failures on stdout 190ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 2, …(2) }
   × runAxiCli subprocess integration > formats 'generic' initialize failures on stdout 196ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 1, …(2) }
   × runAxiCli subprocess integration > formats 'axi' asynchronous initialize rejections on stdout 182ms
     → expected { exitCode: 1, …(2) } to deeply equal { exitCode: 2, …(2) }
   × runAxiCli subprocess integration > formats 'generic' asynchronous initialize rejections on stdout 190ms
     → expected { exitCode: 1, …(2) } to deeply equal { exitCode: 1, …(2) }
   × runAxiCli subprocess integration > formats 'axi' resolveContext failures for home on stdout 190ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 2, …(2) }
   × runAxiCli subprocess integration > formats 'generic' resolveContext failures for home on stdout 188ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 1, …(2) }
   × runAxiCli subprocess integration > formats 'axi' resolveContext failures for commands on stdout 181ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 2, …(2) }
   × runAxiCli subprocess integration > formats 'generic' resolveContext failures for commands on stdout 192ms
     → expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 1, …(2) }
   ✓ runAxiCli subprocess integration > prints version from a real entrypoint for bare --version 225ms
   ✓ runAxiCli subprocess integration > prints version from a real entrypoint for bare -v 226ms
   ✓ runAxiCli subprocess integration > prints version from a real entrypoint for bare -V 227ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 8 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  test/cli.test.ts > runAxiCli subprocess integration > formats 'axi' initialize failures on stdout
AssertionError: expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 2, …(2) }

[32m- Expected[39m
[31m+ Received[39m

[2m  {[22m
[32m-   "exitCode": 2,[39m
[32m-   "stderr": "",[39m
[32m-   "stdout": "error: Invalid fixture request[39m
[32m- code: VALIDATION_ERROR[39m
[32m- help[1]: Run `fixture --help`[39m
[31m+   "exitCode": 1,[39m
[31m+   "stderr": "/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:8[39m
[31m+     return new __vite_ssr_import_0__.AxiError(\"Invalid fixture request\", \"VALIDATION_ERROR\", [[39m
[31m+            ^[39m
[31m+[39m
[31m+ AxiError: Invalid fixture request[39m
[31m+     at fixtureError (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:7:12)[39m
[31m+     at Object.initialize (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:22:17)[39m
[31m+     at runAxiCli (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/src/cli.ts:77:11)[39m
[31m+     at /Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:15:16[39m
[31m+     at ViteNodeRunner.runModule (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:397:4)[39m
[31m+     at ViteNodeRunner.directRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:375:3)[39m
[31m+     at ViteNodeRunner.cachedRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:189:11)[39m
[31m+     at ViteNodeRunner.executeFile (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:162:10)[39m
[31m+     at CAC.run (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/cli.mjs:102:28) {[39m
[31m+   code: 'VALIDATION_ERROR',[39m
[31m+   suggestions: [ 'Run `fixture --help`' ][39m
[31m+ }[39m
[31m+[39m
[31m+ Node.js v26.5.1[39m
[2m  ",[22m
[31m+   "stdout": "",[39m
[2m  }[22m

 ❯ test/cli.test.ts:499:22
    497|       );
    498| 
    499|       expect(result).toEqual({ exitCode, stdout, stderr: "" });
       |                      ^
    500|     },
    501|   );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/8]⎯

 FAIL  test/cli.test.ts > runAxiCli subprocess integration > formats 'generic' initialize failures on stdout
AssertionError: expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 1, …(2) }

[32m- Expected[39m
[31m+ Received[39m

[2m  {[22m
[2m    "exitCode": 1,[22m
[32m-   "stderr": "",[39m
[32m-   "stdout": "error: Dependency exploded[39m
[32m- code: UNKNOWN[39m
[31m+   "stderr": "/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:13[39m
[31m+   return new Error(\"Dependency exploded\");[39m
[31m+          ^[39m
[31m+[39m
[31m+ Error: Dependency exploded[39m
[31m+     at fixtureError (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:12:10)[39m
[31m+     at Object.initialize (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:22:17)[39m
[31m+     at runAxiCli (/Users/nathanbenn

... [13545 bytes truncated] ...

rees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:397:4)[39m
[31m+     at ViteNodeRunner.directRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:375:3)[39m
[31m+     at ViteNodeRunner.cachedRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:189:11)[39m
[31m+     at ViteNodeRunner.executeFile (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:162:10)[39m
[31m+     at CAC.run (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/cli.mjs:102:28)[39m
[31m+[39m
[31m+ Node.js v26.5.1[39m
[2m  ",[22m
[31m+   "stdout": "",[39m
[2m  }[22m

 ❯ test/cli.test.ts:525:22
    523|       );
    524| 
    525|       expect(result).toEqual({ exitCode, stdout, stderr: "" });
       |                      ^
    526|     },
    527|   );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[6/8]⎯

 FAIL  test/cli.test.ts > runAxiCli subprocess integration > formats 'axi' resolveContext failures for commands on stdout
AssertionError: expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 2, …(2) }

[32m- Expected[39m
[31m+ Received[39m

[2m  {[22m
[32m-   "exitCode": 2,[39m
[32m-   "stderr": "",[39m
[32m-   "stdout": "error: Invalid fixture request[39m
[32m- code: VALIDATION_ERROR[39m
[32m- help[1]: Run `fixture --help`[39m
[31m+   "exitCode": 1,[39m
[31m+   "stderr": "/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:8[39m
[31m+     return new __vite_ssr_import_0__.AxiError(\"Invalid fixture request\", \"VALIDATION_ERROR\", [[39m
[31m+            ^[39m
[31m+[39m
[31m+ AxiError: Invalid fixture request[39m
[31m+     at fixtureError (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:7:12)[39m
[31m+     at Object.resolveContext (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:32:17)[39m
[31m+     at runAxiCli (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/src/cli.ts:151:33)[39m
[31m+     at /Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:15:16[39m
[31m+     at ViteNodeRunner.runModule (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:397:4)[39m
[31m+     at ViteNodeRunner.directRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:375:3)[39m
[31m+     at ViteNodeRunner.cachedRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:189:11)[39m
[31m+     at ViteNodeRunner.executeFile (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:162:10)[39m
[31m+     at CAC.run (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/cli.mjs:102:28) {[39m
[31m+   code: 'VALIDATION_ERROR',[39m
[31m+   suggestions: [ 'Run `fixture --help`' ][39m
[31m+ }[39m
[31m+[39m
[31m+ Node.js v26.5.1[39m
[2m  ",[22m
[31m+   "stdout": "",[39m
[2m  }[22m

 ❯ test/cli.test.ts:538:22
    536|       );
    537| 
    538|       expect(result).toEqual({ exitCode, stdout, stderr: "" });
       |                      ^
    539|     },
    540|   );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[7/8]⎯

 FAIL  test/cli.test.ts > runAxiCli subprocess integration > formats 'generic' resolveContext failures for commands on stdout
AssertionError: expected { exitCode: 1, stdout: '', …(1) } to deeply equal { exitCode: 1, …(2) }

[32m- Expected[39m
[31m+ Received[39m

[2m  {[22m
[2m    "exitCode": 1,[22m
[32m-   "stderr": "",[39m
[32m-   "stdout": "error: Dependency exploded[39m
[32m- code: UNKNOWN[39m
[31m+   "stderr": "/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:13[39m
[31m+   return new Error(\"Dependency exploded\");[39m
[31m+          ^[39m
[31m+[39m
[31m+ Error: Dependency exploded[39m
[31m+     at fixtureError (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:12:10)[39m
[31m+     at Object.resolveContext (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:32:17)[39m
[31m+     at runAxiCli (/Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/src/cli.ts:151:33)[39m
[31m+     at /Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/packages/axi-sdk-js/test/fixtures/error-boundary-bin.mjs:15:16[39m
[31m+     at ViteNodeRunner.runModule (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:397:4)[39m
[31m+     at ViteNodeRunner.directRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:375:3)[39m
[31m+     at ViteNodeRunner.cachedRequest (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:189:11)[39m
[31m+     at ViteNodeRunner.executeFile (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/client.mjs:162:10)[39m
[31m+     at CAC.run (file:///Users/nathanbennesby/.no-mistakes/worktrees/fc703883fc95/01KZ28RZ3KEVVAHR61VPRAP47R/node_modules/.pnpm/vite-node@3.2.4_@types+node@22.19.19_tsx@4.21.0_yaml@2.8.4/node_modules/vite-node/dist/cli.mjs:102:28)[39m
[31m+[39m
[31m+ Node.js v26.5.1[39m
[2m  ",[22m
[31m+   "stdout": "",[39m
[2m  }[22m

 ❯ test/cli.test.ts:538:22
    536|       );
    537| 
    538|       expect(result).toEqual({ exitCode, stdout, stderr: "" });
       |                      ^
    539|     },
    540|   );

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[8/8]⎯


 Test Files  1 failed (1)
      Tests  8 failed | 24 passed (32)
   Start at  19:22:25
   Duration  2.42s (transform 50ms, setup 0ms, collect 59ms, tests 2.19s, environment 0ms, prepare 36ms)
```
</details>
- Evidence: Reproducible demo CLI + transcript driver used for the manual verification (local file: <code>/var/folders/dh/ny_k7wbn1lv56zxvwr3jz8100000gn/T/no-mistakes-evidence/01KZ28RZ3KEVVAHR61VPRAP47R/demo-axi</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 3 infos</summary>

- ℹ️ `packages/axi-sdk-js/src/cli.ts:144` - Residual gap of the same class, outside this change&#39;s authorized scope: `options.getCommandHelp?.(command)` (line 144), `options.renderUnknownCommand?.(command)` (line 154), and `options.formatError` inside `writeFormattedError` (line 211) are still invoked with no error boundary. A tool whose `getCommandHelp` throws on `tool issue --help` still produces a raw stack trace on stderr with empty stdout and exit 1 — the exact contract violation just fixed for initialize/resolveContext. The intent scopes the fix to those two phases and asks for the smallest coherent change, so this is reported as informational only, not as an incomplete fix.
- ℹ️ `packages/axi-sdk-js/test/cli.test.ts:40` - `runErrorBoundaryFixture` re-derives the fixture path and the `../node_modules/.bin/vite-node` path plus the `execFileAsync` invocation that the pre-existing version test already inlines at lines 545-557. Extracting one `runFixtureBin(fixtureName, args)` helper that both call would remove the duplicated path resolution and the duplicated `cwd` wiring. Test-only, no behavior impact.
- ℹ️ `packages/axi-sdk-js/src/cli.ts:175` - Observable behavior change for published-SDK consumers: previously `initialize`/`resolveContext` rejections propagated out of `runAxiCli()`, so a tool wrapping the call in its own try/catch saw them. They are now caught and formatted by the SDK, so such an outer catch no longer fires for these phases. This is exactly what the intent requires and tools can still override via `formatError`, so no action is needed — but it is worth one line in the PR body since it ships as a patch bump under the pre-1.0 release-please config.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`pnpm install --filter axi-sdk-js...` then `pnpm --dir packages/axi-sdk-js run build` (tsc build succeeds with the widened `initialize?: () =&gt; MaybePromise&lt;void&gt;` signature)</code>
- <code>`vitest run test/cli.test.ts` in packages/axi-sdk-js — 32 passed, including the 8 new subprocess error-boundary cases</code>
- <code>Red-baseline check: `git checkout 93c5f33 -- packages/axi-sdk-js/src/cli.ts` + rebuild, then `vitest run test/cli.test.ts` — exactly the 8 new tests fail (initialize sync/async, resolveContext home, resolveContext command × AxiError/generic), 24 others pass; file restored and worktree verified clean</code>
- <code>`vitest run` for the axi-sdk-js package (5 suites) to confirm errors/output/hooks/update suites are unaffected by the boundary change</code>
- <code>Manual CLI transcript over a real `demo-axi` executable importing the freshly compiled `dist/index.js`: `bash transcript.sh` capturing stdout/stderr/exit separately for initialize and resolveContext failures (AxiError and generic), handler-throw control, home, `issue list`, `--help`, `--version`, unknown command and leading-flag error</code>
- <code>Same transcript re-run against a dist rebuilt from base `cli.ts` to reproduce the reported defect (empty stdout, stack trace on stderr, exit 1) before/after comparison</code>
- <code>Lazy-context check through the real binary: `--help`, `--version` and an unknown command with `resolveContext` rigged to throw — all succeed, proving context is still resolved only for views that need it</code>
- <code>Exit-code mapping check through the real binary with a `VALIDATION_ERROR` AxiError thrown from initialize and from resolveContext (home and command) — exit 2, stderr empty</code>

</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `packages/axi-sdk-js/README.md:105` - Judgment call, left as-is: the public `initialize` option is not documented in packages/axi-sdk-js/README.md, and this change widened it to `MaybePromise&lt;void&gt;` and moved initialize/resolveContext failures under the handler error boundary. No existing doc states anything now false (the README&#39;s &#34;lazy context resolution&#34; claim still holds), and the invariant is owned by the code comment in packages/axi-sdk-js/src/cli.ts at the boundary, so documenting `initialize` here would add a new fact rather than fix a stale one. If maintainers want the option surfaced to AXI authors, a follow-up should add it to the README Reference table alongside the structured-error contract for the initialize phase.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
