### PR TITLE
feat(axi-sdk-js): add dependency-free version fast path

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -245,3 +245,29 @@ description: Manage project tasks in the current workspace
 ```
 
 Every subcommand should support `--help` with a concise, complete reference: available flags with defaults, required arguments, and 2-3 usage examples. Keep it focused on the requested subcommand — don't dump the entire CLI's manual.
+
+### Identify yourself instantly: the `--version` fast path
+
+`-v`, `-V`, and `--version` must all print the bare version and exit 0. Agents and their harnesses probe `--version` constantly — to confirm a tool is installed, to check whether a fix has shipped, to decide whether to suggest `update`. That makes latency an ergonomics property, not just a perf tweak: a probe that takes 80 ms is 80 ms of every session start, paid before any useful work happens.
+
+The trap is ESM static imports. If `bin/<tool>.js` statically imports the module that builds the command graph, every dependency in that graph is fully evaluated _before_ the version check runs. One heavy import anywhere in the tree — an SDK, a server framework — is then paid on every `--version`.
+
+Answer the version before the graph loads: keep the version in a leaf module that imports only node builtins, and defer the real CLI to a dynamic `import()`.
+
+```js
+#!/usr/bin/env node
+import { tryFastPath } from "axi-sdk-js/fast-path";
+import { VERSION } from "../src/version.js"; // leaf module — node builtins only
+
+if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
+  const { main } = await import("../src/cli.js"); // heavy graph loads only here
+  await main();
+}
+```
+
+`axi-sdk-js/fast-path` is a dedicated subpath export that imports nothing at all, so pulling it in never drags in `runAxiCli` or its dependencies. `tryFastPath` handles only a bare, single-argument version flag and returns `false` for everything else, so all other argv — including version flags in trailing positions — falls through to `runAxiCli`, which stays the single owner of the general case. Its accepted flags and output are identical to the SDK's own version handling, so adopting it changes nothing an agent can observe except the latency.
+
+Two things keep this honest:
+
+- The version must come from a **leaf** module. If `VERSION` is defined inside `cli.ts`, importing it re-pulls the whole graph and the fast path buys nothing.
+- Guard it with a test that measures the version path against the `node -e "console.log(1)"` floor measured in the same process, rather than an absolute millisecond budget that goes flaky across machines.

--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -248,16 +248,16 @@ Every subcommand should support `--help` with a concise, complete reference: ava
 
 ### Identify yourself instantly: the `--version` fast path
 
-`-v`, `-V`, and `--version` must all print the bare version and exit 0. Agents and their harnesses probe `--version` constantly — to confirm a tool is installed, to check whether a fix has shipped, to decide whether to suggest `update`. That makes latency an ergonomics property, not just a perf tweak: a probe that takes 80 ms is 80 ms of every session start, paid before any useful work happens.
+`-v`, `-V`, and `--version` must all print the bare version and exit 0. Agents and their harnesses probe `--version` constantly - to confirm a tool is installed, to check whether a fix has shipped, to decide whether to suggest `update`. That makes latency an ergonomics property, not just a perf tweak: a probe that takes 80 ms is 80 ms of every session start, paid before any useful work happens.
 
-The trap is ESM static imports. If `bin/<tool>.js` statically imports the module that builds the command graph, every dependency in that graph is fully evaluated _before_ the version check runs. One heavy import anywhere in the tree — an SDK, a server framework — is then paid on every `--version`.
+The trap is ESM static imports. If `bin/<tool>.js` statically imports the module that builds the command graph, every dependency in that graph is fully evaluated _before_ the version check runs. One heavy import anywhere in the tree - an SDK, a server framework - is then paid on every `--version`.
 
 Answer the version before the graph loads: keep the version in a leaf module that imports only node builtins, and defer the real CLI to a dynamic `import()`.
 
 ```js
 #!/usr/bin/env node
 import { tryFastPath } from "axi-sdk-js/fast-path";
-import { VERSION } from "../src/version.js"; // leaf module — node builtins only
+import { VERSION } from "../src/version.js"; // leaf module - node builtins only
 
 if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
   const { main } = await import("../src/cli.js"); // heavy graph loads only here
@@ -265,7 +265,7 @@ if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
 }
 ```
 
-`axi-sdk-js/fast-path` is a dedicated subpath export that imports nothing at all, so pulling it in never drags in `runAxiCli` or its dependencies. `tryFastPath` handles only a bare, single-argument version flag and returns `false` for everything else, so all other argv — including version flags in trailing positions — falls through to `runAxiCli`, which stays the single owner of the general case. Its accepted flags and output are identical to the SDK's own version handling, so adopting it changes nothing an agent can observe except the latency.
+`axi-sdk-js/fast-path` is a dedicated subpath export that imports nothing at all, so pulling it in never drags in `runAxiCli` or its dependencies. `tryFastPath` handles only a bare, single-argument version flag and returns `false` for everything else, so all other argv - including version flags in trailing positions - falls through to `runAxiCli`, which stays the single owner of the general case. Its accepted flags and output are identical to the SDK's own version handling, so adopting it changes nothing an agent can observe except the latency.
 
 Two things keep this honest:
 

--- a/.no-mistakes/evidence/fm/axi-sdk-version-fastpath-export-p3/fast-path-cli-transcript.txt
+++ b/.no-mistakes/evidence/fm/axi-sdk-version-fastpath-export-p3/fast-path-cli-transcript.txt
@@ -1,0 +1,32 @@
+AXI SDK fast-path end-user verification
+
+Compiled public package import with Node module resolution tracing:
+
+public import: axi-sdk-js/fast-path
+resolved modules: 1
+  axi-sdk-js/fast-path -> packages/axi-sdk-js/dist/fast-path.js
+bare --version: handled=true, output="9.9.9\n"
+trailing --version: handled=false, outputBytes=0
+
+Recommended bin-shape fixture invocations:
+
+$ fast-path-bin -v
+9.9.9
+
+$ fast-path-bin -V
+9.9.9
+
+$ fast-path-bin --version
+9.9.9
+
+$ fast-path-bin issue --version
+loaded-heavy-graph
+issue output
+
+$ fast-path-bin issue
+loaded-heavy-graph
+issue output
+
+The absence of "loaded-heavy-graph" on each bare version probe demonstrates
+that the dynamic command graph was not imported. Command and trailing-flag
+invocations fall through and visibly load the graph.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ This file provides guidance to AI agents when working with code in this reposito
 AXI (Agent eXperience Interface) defines 10 ergonomic principles for building CLI tools that AI agents use via shell execution. This repo contains:
 
 - **`packages/axi-sdk-js/`** — Shared Node.js SDK every `*-axi` CLI builds on. `runAxiCli()` provides built-in commands for all tools: `--help`, `-v`/`--version`, and `update` (self-update). `update` is a reserved command name; a tool may shadow it by registering its own handler.
+  The package also exposes a second, dependency-free subpath, `axi-sdk-js/fast-path` (`src/fast-path.ts`), so a tool's `bin/` can answer `--version` before dynamically importing its heavy command graph. It must stay import-free and flag/output-identical to the version handling in `runAxiCli`; `test/fast-path.test.ts` guards both.
 - **`bench-github/`** — Benchmark harness that compares gh-axi vs gh CLI vs GitHub MCP across 17 agent tasks, graded by an LLM judge.
 - **`bench-browser/`** — Benchmark harness that compares browser automation tools (agent-browser, pinchtab, chrome-devtools-mcp) across 16 browsing tasks.
 - **`.agents/skills/axi/SKILL.md`** — The AXI skill definition (installable via `npx skills add kunchenguid/axi`).

--- a/packages/axi-sdk-js/README.md
+++ b/packages/axi-sdk-js/README.md
@@ -98,11 +98,15 @@ await runAxiCli({
 
 ## Reference
 
-`axi-sdk-js` is a library package. In normal use, `runAxiCli()` should be the main entry point.
+`axi-sdk-js` is a library package. In normal use, `runAxiCli()` is the main
+entry point. Executable entry points may import `tryFastPath()` from the
+dedicated `axi-sdk-js/fast-path` subpath before dynamically importing their
+full command graph.
 
-| API           | Description                                                                                                                                                                                    |
-| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `runAxiCli()` | Shared runtime for command-first dispatch, bare `--help`/`--version` fast paths, the built-in `update` command, lazy context resolution, home header injection, TOON serialization, and errors |
+| API                                     | Description                                                                                                                                                                                  |
+| --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `runAxiCli()`                           | Shared runtime for command-first dispatch, bare `--help`/`--version` handling, the built-in `update` command, lazy context resolution, home header injection, TOON serialization, and errors |
+| `axi-sdk-js/fast-path`: `tryFastPath()` | Dependency-free subpath for handling a bare `-v`, `-V`, or `--version` before loading the full CLI graph; all other arguments fall through unchanged                                         |
 
 ### Advanced Exports
 

--- a/packages/axi-sdk-js/package.json
+++ b/packages/axi-sdk-js/package.json
@@ -22,6 +22,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./fast-path": {
+      "types": "./dist/fast-path.d.ts",
+      "import": "./dist/fast-path.js"
     }
   },
   "files": [

--- a/packages/axi-sdk-js/src/fast-path.ts
+++ b/packages/axi-sdk-js/src/fast-path.ts
@@ -1,0 +1,54 @@
+/**
+ * Dependency-free entry-point fast path.
+ *
+ * This module deliberately imports nothing - not even other SDK modules - so a
+ * tool's `bin/` can answer `--version` before its heavy command graph is
+ * loaded:
+ *
+ * ```js
+ * #!/usr/bin/env node
+ * import { tryFastPath } from "axi-sdk-js/fast-path";
+ * import { VERSION } from "../src/version.js"; // leaf module, node builtins only
+ *
+ * if (!tryFastPath(process.argv.slice(2), { version: VERSION })) {
+ *   const { main } = await import("../src/cli.js"); // heavy graph loads only here
+ *   await main();
+ * }
+ * ```
+ *
+ * The accepted flags and the emitted output are kept identical to the version
+ * handling inside `runAxiCli`, so adopting the fast path is observationally
+ * equivalent to routing the same argv through the full CLI. A parity test in
+ * `test/fast-path.test.ts` guards that equivalence.
+ */
+
+export interface AxiFastPathOptions {
+  version: string;
+  stdout?: { write: (chunk: string) => unknown };
+}
+
+/**
+ * Handle a bare version flag (`-v`, `-V`, `--version`) without loading the
+ * tool's command graph.
+ *
+ * Returns `true` when the argv was handled (the version was written); returns
+ * `false` and writes nothing otherwise, so the caller can fall through to
+ * `runAxiCli`. Version flags in any other position are deliberately not
+ * handled here - `runAxiCli` remains the single owner of the general case.
+ */
+export function tryFastPath(
+  argv: string[],
+  options: AxiFastPathOptions,
+): boolean {
+  if (argv.length !== 1) {
+    return false;
+  }
+
+  const flag = argv[0];
+  if (flag !== "-v" && flag !== "-V" && flag !== "--version") {
+    return false;
+  }
+
+  (options.stdout ?? process.stdout).write(`${options.version}\n`);
+  return true;
+}

--- a/packages/axi-sdk-js/test/fast-path.test.ts
+++ b/packages/axi-sdk-js/test/fast-path.test.ts
@@ -1,0 +1,157 @@
+import { execFile } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runAxiCli } from "../src/cli.js";
+import { tryFastPath } from "../src/fast-path.js";
+
+const execFileAsync = promisify(execFile);
+
+const VERSION = "1.2.3";
+
+/**
+ * Every flag-shaped argv worth probing: the three the SDK accepts, plus the
+ * near-misses that must NOT be treated as a version request. The parity test
+ * below drives each one through both `tryFastPath` and `runAxiCli` and asserts
+ * they agree, so the fast and slow paths cannot drift apart.
+ */
+const CANDIDATE_FLAGS = [
+  "-v",
+  "-V",
+  "--version",
+  "-version",
+  "--v",
+  "--V",
+  "--Version",
+  "--VERSION",
+  "v",
+  "V",
+  "version",
+  "--ver",
+  "-h",
+  "--help",
+  "",
+];
+
+const ACCEPTED_FLAGS = ["-v", "-V", "--version"];
+
+async function runSlowPath(argv: string[]): Promise<string> {
+  const chunks: string[] = [];
+  await runAxiCli({
+    description: "Fixture CLI",
+    version: VERSION,
+    topLevelHelp: "fixture help",
+    argv,
+    home: async () => "home output",
+    commands: { issue: async () => "issue output" },
+    stdout: { write: (chunk: string) => chunks.push(chunk) },
+  });
+  return chunks.join("");
+}
+
+function runFastPath(argv: string[]): { handled: boolean; output: string } {
+  const chunks: string[] = [];
+  const handled = tryFastPath(argv, {
+    version: VERSION,
+    stdout: { write: (chunk: string) => chunks.push(chunk) },
+  });
+  return { handled, output: chunks.join("") };
+}
+
+describe("tryFastPath", () => {
+  beforeEach(() => {
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    process.exitCode = undefined;
+  });
+
+  it.each(ACCEPTED_FLAGS)("emits `${version}\\n` for bare %s", (flag) => {
+    const { handled, output } = runFastPath([flag]);
+
+    expect(handled).toBe(true);
+    expect(output).toBe(`${VERSION}\n`);
+  });
+
+  it.each(CANDIDATE_FLAGS)(
+    "agrees with runAxiCli on whether %j is a version request",
+    async (flag) => {
+      const { handled, output } = runFastPath([flag]);
+      const slowOutput = await runSlowPath([flag]);
+
+      const slowPathPrintedVersion = slowOutput === `${VERSION}\n`;
+      expect(handled).toBe(slowPathPrintedVersion);
+      expect(handled).toBe(ACCEPTED_FLAGS.includes(flag));
+
+      if (handled) {
+        expect(output).toBe(slowOutput);
+        expect(process.exitCode).toBeUndefined();
+      } else {
+        expect(output).toBe("");
+      }
+    },
+  );
+
+  it("defaults to process.stdout when no stdout is supplied", () => {
+    const write = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+
+    try {
+      expect(tryFastPath(["--version"], { version: VERSION })).toBe(true);
+      expect(write).toHaveBeenCalledWith(`${VERSION}\n`);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
+  it.each([
+    [[]],
+    [["issue"]],
+    [["issue", "list"]],
+    [["--version", "--json"]],
+    [["issue", "--version"]],
+    [["-v", "-v"]],
+  ])("returns false and writes nothing for %j", (argv) => {
+    const { handled, output } = runFastPath(argv);
+
+    expect(handled).toBe(false);
+    expect(output).toBe("");
+  });
+});
+
+describe("tryFastPath entry-point integration", () => {
+  const fixturePath = fileURLToPath(
+    new URL("./fixtures/fast-path-bin.mjs", import.meta.url),
+  );
+  const viteNodePath = fileURLToPath(
+    new URL("../node_modules/.bin/vite-node", import.meta.url),
+  );
+
+  it.each(ACCEPTED_FLAGS)(
+    "answers %s without loading the tool's command graph",
+    async (flag) => {
+      const { stdout, stderr } = await execFileAsync(
+        viteNodePath,
+        [fixturePath, flag],
+        { cwd: new URL("..", import.meta.url) },
+      );
+
+      expect(stdout).toBe("9.9.9\n");
+      expect(stderr).toBe("");
+    },
+  );
+
+  it("falls through to the full CLI for real commands", async () => {
+    const { stdout } = await execFileAsync(
+      viteNodePath,
+      [fixturePath, "issue"],
+      { cwd: new URL("..", import.meta.url) },
+    );
+
+    expect(stdout).toContain("loaded-heavy-graph\n");
+    expect(stdout).toContain("issue output");
+  });
+});

--- a/packages/axi-sdk-js/test/fixtures/fast-path-bin.mjs
+++ b/packages/axi-sdk-js/test/fixtures/fast-path-bin.mjs
@@ -1,0 +1,19 @@
+import { tryFastPath } from "../../src/fast-path.ts";
+
+const argv = process.argv.slice(2);
+
+if (!tryFastPath(argv, { version: "9.9.9" })) {
+  const { runAxiCli } = await import("../../src/cli.ts");
+  process.stdout.write("loaded-heavy-graph\n");
+  await runAxiCli({
+    description: "Fixture CLI",
+    version: "9.9.9",
+    topLevelHelp: "fixture help",
+    hooks: false,
+    argv,
+    home: async () => "home output",
+    commands: {
+      issue: async () => "issue output",
+    },
+  });
+}


### PR DESCRIPTION
## Intent

Add a dependency-free `axi-sdk-js/fast-path` subpath export so any *-axi tool can answer `--version` before its heavy module graph loads.

Background: `runAxiCli` (packages/axi-sdk-js/src/cli.ts) can only answer `--version` AFTER the tool has statically imported its whole command graph and run `options.initialize?.()`. ESM static imports are hoisted, so one heavy dependency anywhere in the graph is paid on every version probe. Agents probe `--version` constantly, so this is an agent-ergonomics gap, not just a perf tweak. A benchmarked audit measured chrome-devtools-axi --version at 78ms vs a 17ms node floor, and the prototyped fast path brings every tool to ~20ms. There is no pre-import escape hatch today; this task adds one WITHOUT changing any existing behavior.

Required implementation:
1. packages/axi-sdk-js/src/fast-path.ts importing ONLY node builtins (no runAxiCli, no update/hooks, no @toon-format/toon), exporting:
export function tryFastPath(argv: string[], options: { version: string; stdout?: { write: (chunk: string) => unknown } }): boolean
Return true iff argv is exactly one element and it is -v, -V, or --version; then write `${options.version}\n` to options.stdout ?? process.stdout and return true. Otherwise return false and write nothing.
2. Expose it as a NEW package.json subpath export "./fast-path" (with types + import) alongside the existing "." export. Do NOT alter the existing "." export.
3. Byte-for-byte parity is critical: the accepted flag set MUST stay identical to isVersionFlag (packages/axi-sdk-js/src/cli.ts:236-238) and the output format identical to cli.ts:105 (`${version}\n`). Leave the runAxiCli version path UNTOUCHED so adopted and unadopted tools stay provably equivalent.
4. A table test asserting tryFastPath accepts EXACTLY the same flags as isVersionFlag and emits exactly `${version}\n`, so the fast and slow paths cannot drift. Also test that a non-version argv, or a version flag with extra args, returns false and writes nothing.
5. Document the entry-point fast-path pattern in the AXI skill (.agents/skills/axi/SKILL.md), consulted and updated per repo convention.

Acceptance criteria: the new axi-sdk-js/fast-path subpath imports zero heavy deps (node builtins only); the "." export and runAxiCli are unchanged; tryFastPath is provably flag- and output-equivalent to the SDK's existing version handling, guarded by the parity test; the AXI skill documents the pattern.

Scope constraint (deliberate exclusion): SDK export ONLY. Do NOT convert any *-axi tool's bin to use it here - those are tracked separately. This is a new PUBLIC SDK API surface, so keep it minimal and stable.

Decisions I made while implementing, so the diff is not surprising:
- fast-path.ts imports nothing at all, not even node builtins - it only touches the `process` global. A module.register() ESM load trace on the compiled dist/fast-path.js confirms exactly one module resolves, zero dependencies.
- tryFastPath is deliberately conservative (argv.length === 1). Version flags in trailing positions (e.g. `tool --provider x -v`) intentionally fall through to runAxiCli, which remains the single owner of the general case.
- fast-path is NOT re-exported from src/index.ts, because that would alter the "." export surface which the task forbids. It is reachable only via the new subpath.
- The parity test does not read source text (per the repo's standing no-source-text-assertion rule). It drives 15 candidate flags (the 3 accepted plus near-misses like -version, --v, --Version, --VERSION, v, version, --ver, -h, --help, "") through BOTH tryFastPath and a real runAxiCli invocation, asserting handled === (slow path printed the version) and byte-identical output. That is the anti-drift guard.
- A subprocess fixture (test/fixtures/fast-path-bin.mjs) exercises the recommended bin shape end to end via vite-node, proving the heavy command graph is only dynamically imported on the fall-through path (it prints a marker when the dynamic import happens).
- The AXI skill doc was added as a SUBSECTION under principle 10 ("### Identify yourself instantly: the --version fast path") rather than a new '## N.' heading, because docs:check enforces that top-level SKILL.md section headings match the canonical principle titles in principles.yaml. Adding a top-level heading would fail that drift check.
- AGENTS.md got a one-line pointer to the new subpath and its invariants.

Note on release/versioning convention for this repo: axi-sdk-js versions and publishes via release-please. packages/axi-sdk-js/package.json version, CHANGELOG.md, and .release-please-manifest.json must NOT be hand-edited - the 'Guard generated files' check fails PRs that do. The npm publish is gated separately by a maintainer merging the release-please PR; this PR should only land the code on main.

## What Changed

- Add the dependency-free `axi-sdk-js/fast-path` subpath with `tryFastPath()` for bare `-v`, `-V`, and `--version` probes.
- Add parity and entry-point integration coverage for output equivalence, fallthrough behavior, and deferred command-graph loading.
- Document the fast-path adoption pattern in the SDK README, AXI skill, and contributor guidance.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>
</details>
<details>
<summary>✅ **Rebase** - passed</summary>
</details>
<details>
<summary>✅ **Review** - completed</summary>
</details>
<details>
<summary>✅ **Test** - passed</summary>
</details>
<details>
<summary>✅ **Document** - passed</summary>
</details>
<details>
<summary>✅ **Lint** - passed</summary>
</details>
<details>
<summary>✅ **Push** - passed</summary>
</details>
