### PR TITLE
docs: add pg-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AXIs built and maintained by the community:
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 | [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
+| [`pg-axi`](https://github.com/Abdul-Rehman6/pg-axi)                                                | Abdul-Rehman6      | PostgreSQL            | Inspect schemas, run capped queries, and read query plans over the shell - token-efficient TOON output, partition-aware row counts.                          |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -151,3 +151,8 @@ community:
     author: karotkriss
     domain: GitLab
     description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."
+  - name: pg-axi
+    url: https://github.com/Abdul-Rehman6/pg-axi
+    author: Abdul-Rehman6
+    domain: PostgreSQL
+    description: "Inspect schemas, run capped queries, and read query plans over the shell - token-efficient TOON output, partition-aware row counts."

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,6 +711,20 @@
                     glab CLI with agent-ergonomic TOON output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/Abdul-Rehman6/pg-axi"
+                      ><code>pg-axi</code></a
+                    >
+                  </td>
+                  <td>Abdul-Rehman6</td>
+                  <td>PostgreSQL</td>
+                  <td>
+                    Inspect schemas, run capped queries, and read query plans
+                    over the shell - token-efficient TOON output,
+                    partition-aware row counts.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## What Changed

- Added a `pg-axi` entry (author `Abdul-Rehman6`, domain PostgreSQL) to the `community` list in `catalog.yaml`.
- Regenerated the community catalog tables in `README.md` and `docs/index.html` with the matching row.

## Risk Assessment

✅ Low: Docs-only addition of one community catalog entry; the generated README and HTML regions are consistent with what scripts/generate-docs.mjs plus prettier would emit, and the linked repository resolves.

## Testing

Ran the docs generator's own check and unit tests to prove the committed README and site rows are exactly what catalog.yaml generates, then rendered docs/index.html in headless Chrome and captured a screenshot of the Community table showing the new pg-axi row as an end user would see it, and confirmed the linked repo URL returns 200. Everything the change intended works, but the visual check revealed the catalog already contains a different pg-axi entry (thatdudealso, also PostgreSQL), so two identically-named rows now appear and the generator has no duplicate-name guard - that needs an author decision.

- Evidence: Rendered community catalog table showing the new pg-axi row (headless Chrome, docs/index.html) (local file: <code>/var/folders/3g/gf0z3mxn10963w_9yz8k3jm40000gq/T/no-mistakes-evidence/01KZDGGZ46T0MP11S3GMYZD979/community-catalog-pg-axi.png</code>)
- Evidence: Community catalog table top (context for the rendered section) (local file: <code>/var/folders/3g/gf0z3mxn10963w_9yz8k3jm40000gq/T/no-mistakes-evidence/01KZDGGZ46T0MP11S3GMYZD979/community-catalog.png</code>)
<details>
<summary>Evidence: Generated README rows - both pg-axi entries</summary>

```text
$ grep -n "pg-axi" README.md
138:| [`pg-axi`](https://github.com/thatdudealso/pg-axi) | thatdudealso | PostgreSQL | Discover, create, inspect, query, back up, restore, and maintain PostgreSQL databases through safe token-efficient CLI workflows. |
147:| [`pg-axi`](https://github.com/Abdul-Rehman6/pg-axi) | Abdul-Rehman6 | PostgreSQL | Inspect schemas, run capped queries, and read query plans over the shell - token-efficient TOON output, partition-aware row counts. |
```
</details>
<details>
<summary>Evidence: docs:check - generated regions match catalog.yaml</summary>

```text
$ pnpm run docs:check
docs:check ok — generated regions match their sources
```
</details>
- Outcome: ⏭️ skipped across 1 run (2m39s)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⏭️ **Test** - skipped</summary>

- ⚠️ `catalog.yaml:154` - The community catalog now lists two distinct entries both named `pg-axi` in the PostgreSQL domain: the pre-existing `thatdudealso/pg-axi` (catalog.yaml:109) and the newly added `Abdul-Rehman6/pg-axi` (catalog.yaml:154). The docs generator performs no duplicate-name validation, so `pnpm run docs:check` passes and the rendered site + README show two identically-labelled `pg-axi` rows, which is ambiguous for readers choosing a tool. Needs a product decision: rename the new entry, disambiguate the label, or accept the collision.
- <code>`pnpm install --ignore-scripts` (workspace deps for the docs generator)</code>
- <code>`pnpm run docs:check` - regenerates catalog regions from catalog.yaml and asserts committed README.md / docs/index.html match; passed with no drift</code>
- <code>`pnpm run docs:test` (`node --test scripts/generate-docs.test.mjs`) - generator escaping/link/table semantics; 4/4 passed</code>
- <code>Manual render: headless Chrome screenshot of `docs/index.html` community catalog table, confirming the new pg-axi row renders with correct author, domain, description and link</code>
- <code>`curl -s -o /dev/null -w &#34;%{http_code}&#34; https://github.com/Abdul-Rehman6/pg-axi` - catalog URL resolves (200)</code>
- <code>`grep -n &#34;pg-axi&#34; catalog.yaml README.md docs/index.html` - surfaced the duplicate-name collision with the existing thatdudealso/pg-axi entry</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
