### PR TITLE
docs: add comfy-cloud-axi to community catalog

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -486,6 +486,21 @@
                     integration auth.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/intelligentrascal/comfy-cloud-axi"
+                      ><code>comfy-cloud-axi</code></a
+                    >
+                  </td>
+                  <td>intelligentrascal</td>
+                  <td>AI generation</td>
+                  <td>
+                    Generate images and videos, submit workflows, and manage
+                    Comfy Cloud jobs from the shell — wraps the Comfy Cloud MCP
+                    server with token-efficient TOON output and contextual
+                    next-step suggestions.
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
Adds comfy-cloud-axi to the community catalog. AXI-compliant CLI for Comfy Cloud MCP with TOON output.

Note: no-mistakes is not installed in this environment. The PR was opened directly. If the Require no-mistakes check fails, this PR will need to be re-submitted through the no-mistakes workflow.