### PR TITLE
docs: add supabase-axi to the community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AXIs built and maintained by the community:
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 | [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
+| [`supabase-axi`](https://github.com/laizhenyoong/supabase-axi)                                     | laizhenyoong       | Supabase              | Inspect schemas, run SQL, and audit RLS, indexes, and logs across Supabase projects. Wraps the Supabase Management API.                                      |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -151,3 +151,8 @@ community:
     author: karotkriss
     domain: GitLab
     description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."
+  - name: supabase-axi
+    url: https://github.com/laizhenyoong/supabase-axi
+    author: laizhenyoong
+    domain: Supabase
+    description: "Inspect schemas, run SQL, and audit RLS, indexes, and logs across Supabase projects. Wraps the Supabase Management API."

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,6 +711,19 @@
                     glab CLI with agent-ergonomic TOON output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/laizhenyoong/supabase-axi"
+                      ><code>supabase-axi</code></a
+                    >
+                  </td>
+                  <td>laizhenyoong</td>
+                  <td>Supabase</td>
+                  <td>
+                    Inspect schemas, run SQL, and audit RLS, indexes, and logs
+                    across Supabase projects. Wraps the Supabase Management API.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

The developer wanted to contribute their existing supabase-axi CLI tool to the AXI project's community catalog, following the repo's CONTRIBUTING guide, on a short branch named add-supabase-axi. They asked for a short, clean catalog entry and iterated repeatedly on the description wording, first rejecting a version that appended a differentiator clause about reads being read-only inside Postgres and writes requiring --write, then asking that it be rewritten to match the style of the official entries like gh-axi and chrome-devtools-axi (a noun/verb list followed by a "Wraps ..." sentence), settling on "Inspect schemas, run SQL, and audit RLS, indexes, and logs across Supabase projects. Wraps the Supabase Management API." They wanted the generated README.md and docs/index.html regenerated via docs:gen, and explicitly asked that the commit carry no co-author trailer. Because CONTRIBUTING requires it, they also agreed to install the no-mistakes gate and gh, fork kunchenguid/axi while leaving origin pointed at the parent repo, and push the change through the no-mistakes pipeline rather than directly to origin.

## What Changed

- Added a `supabase-axi` entry (author `laizhenyoong`, domain Supabase) to the `community` list in `catalog.yaml`.
- Regenerated the marked community-catalog regions of `README.md` and `docs/index.html` so both render the new row.

## Risk Assessment

✅ Low: Docs-only catalog addition whose generated README/HTML regions are consistent with the generator's formatting, links to a verified public repo, and touches no source, workflow, or release-managed files.

## Testing

I validated the catalog contribution end-to-end as a reader would see it: ran the repo's docs generator in check mode (passes, proving the README and docs/index.html regions were regenerated from catalog.yaml rather than hand-edited), ran the generator's own unit tests, then rendered docs/index.html in headless Chrome and captured screenshots showing supabase-axi as the final Community row with author laizhenyoong, domain Supabase, the agreed description, and a live repo link (URL returns HTTP 200). One setup issue I worked around: pnpm fails under this machine's default Node 23.3.0, so I installed and ran under Node 24; the worktree was left clean afterward. Everything passed and no findings.

- Evidence: Rendered docs/index.html — Community catalog table with supabase-axi row (local file: <code>/var/folders/h1/z894nqbd6vlfzgl9tkkn092w0000gn/T/no-mistakes-evidence/01KZKBMAN6V3T7Q53HT78XZDJE/docs-community-catalog.png</code>)
- Evidence: Close-up: supabase-axi row alongside glab-axi for style comparison (local file: <code>/var/folders/h1/z894nqbd6vlfzgl9tkkn092w0000gn/T/no-mistakes-evidence/01KZKBMAN6V3T7Q53HT78XZDJE/supabase-axi-catalog-row.png</code>)
<details>
<summary>Evidence: docs:check output</summary>

```text
$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"36fa657473bf732ebefbac15035947063f203d76","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`node scripts/generate-docs.mjs --check` (repo&#39;s `docs:check`) — generated README/docs regions match catalog.yaml</code>
- <code>`node --test scripts/generate-docs.test.mjs` — 4/4 generator escaping and link-safety tests pass</code>
- <code>Rendered `docs/index.html` headless in Chrome and screenshotted the Community catalog table showing the new supabase-axi row</code>
- <code>`curl -s -o /dev/null -w &#39;%{http_code}&#39; https://github.com/laizhenyoong/supabase-axi` → 200</code>
- <code>`pnpm install` under Node 24 (default Node 23.3.0 in this env cannot run pnpm 11: missing `node:sqlite`)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
