### PR TITLE
docs: add ado-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AXIs built and maintained by the community:
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 | [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
+| [`ado-axi`](https://github.com/dtabolich/ado-axi)                                                  | dtabolich          | Azure DevOps          | Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (`az devops` / `az repos`) with agent-ergonomic TOON output.                       |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -151,3 +151,8 @@ community:
     author: karotkriss
     domain: GitLab
     description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."
+  - name: ado-axi
+    url: https://github.com/dtabolich/ado-axi
+    author: dtabolich
+    domain: Azure DevOps
+    description: "Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (`az devops` / `az repos`) with agent-ergonomic TOON output."

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,6 +711,20 @@
                     glab CLI with agent-ergonomic TOON output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/dtabolich/ado-axi"
+                      ><code>ado-axi</code></a
+                    >
+                  </td>
+                  <td>dtabolich</td>
+                  <td>Azure DevOps</td>
+                  <td>
+                    Pull requests, branches, repositories, and pipeline runs.
+                    Wraps Azure CLI (<code>az devops</code> /
+                    <code>az repos</code>) with agent-ergonomic TOON output.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## Intent

Contribute ado-axi to the AXI community catalog so it shows on axi.md. Append the ado-axi community entry (Azure DevOps domain; wraps az devops/az repos with agent-ergonomic TOON output) from the local ado-axi AXI_CATALOG_ENTRY.md draft into catalog.yaml, regenerate README.md and docs/index.html via pnpm run docs:gen without hand-editing generated tables, and open the PR through no-mistakes against kunchenguid/axi. Do not npm publish or do destructive git ops. Prior runs failed only due to pipeline-agent auth/runtime issues (Claude 403; OpenCode big-pickle tool_choice error); agent is now cursor via acpx.

## What Changed
- Appended the `ado-axi` community catalog entry (Azure DevOps; wraps `az devops` / `az repos` with agent-ergonomic TOON output) to `catalog.yaml`.
- Regenerated the community catalog tables in `README.md` and `docs/index.html` so `ado-axi` appears on axi.md.

## Risk Assessment

✅ Low: Bounded community-catalog append with matching generated docs and no behavioral or security surface beyond listing a public repo.

## Testing

Ran docs:check and docs:test, confirmed the ado-axi community entry regenerates into README/docs, and captured screenshots of the rendered axi.md Community table showing ado-axi (dtabolich, Azure DevOps, az devops/az repos TOON description) - all passed with no issues.

- Evidence: axi.md Community catalog including ado-axi (local file: <code>/var/folders/40/nwkq03v17kd0f94bn69p8qn80000gn/T/no-mistakes-evidence/01KZM42BHCZYNNJECK47EEMS04/axi-md-community-catalog-ado-axi.png</code>)
- Evidence: ado-axi community catalog row (close-up) (local file: <code>/var/folders/40/nwkq03v17kd0f94bn69p8qn80000gn/T/no-mistakes-evidence/01KZM42BHCZYNNJECK47EEMS04/axi-md-ado-axi-row.png</code>)
<details>
<summary>Evidence: Rendered ado-axi row visibility probe</summary>

<code>{&#10;&#34;visible&#34;: true,&#10;&#34;href&#34;: &#34;https://github.com/dtabolich/ado-axi&#34;,&#10;&#34;cells&#34;: [&#10;&#34;ado-axi&#34;,&#10;&#34;dtabolich&#34;,&#10;&#34;Azure DevOps&#34;,&#10;&#34;Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (az devops / az repos) with agent-ergonomic TOON output.&#34;&#10;],&#10;&#34;sectionLabel&#34;: &#34;Community&#34;&#10;}</code>

```text
{
  "visible": true,
  "href": "https://github.com/dtabolich/ado-axi",
  "cells": [
    "ado-axi",
    "dtabolich",
    "Azure DevOps",
    "Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (az devops / az repos) with agent-ergonomic TOON output."
  ],
  "sectionLabel": "Community"
}
```
</details>
<details>
<summary>Evidence: docs:check / docs:test + generated catalog transcript</summary>

```text
$ pnpm run docs:check
$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources

$ pnpm run docs:test
$ node --test scripts/generate-docs.test.mjs
✔ catalog HTML escapes text and attribute values (0.458708ms)
✔ catalog HTML rejects unsafe link protocols (0.158417ms)
✔ catalog HTML supports Markdown link destinations with parentheses (0.070875ms)
✔ catalog Markdown tables preserve pipes and multiline cells (0.14875ms)
ℹ tests 4
ℹ suites 0
ℹ pass 4
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 53.579083

--- README generated community row ---
30:| [`ado-axi`](https://github.com/dtabolich/ado-axi)                                                  | dtabolich          | Azure DevOps          | Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (`az devops` / `az repos`) with agent-ergonomic TOON output.                       |

--- catalog.yaml ado-axi entry ---
  - name: ado-axi
    url: https://github.com/dtabolich/ado-axi
    author: dtabolich
    domain: Azure DevOps
    description: "Pull requests, branches, repositories, and pipeline runs. Wraps Azure CLI (`az devops` / `az repos`) with agent-ergonomic TOON output."
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"36f55e0d4b581ffbad774b4f51d2729e926cddb9","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `pnpm run docs:check`
- `pnpm run docs:test`
- <code>Semantic parse of `catalog.yaml` community entry for ado-axi (name/url/author/domain/description)</code>
- <code>Manual browser render of `docs/index.html` via local HTTP server + Chrome headless screenshots of Community catalog card and ado-axi row</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
