### PR TITLE
docs: correct gh-axi issue listing example

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1069,7 +1069,7 @@ AVAILABLE COMMANDS
           </div>
           <div class="card">
             <p class="section-label">AXI: no-args shows live state</p>
-            <pre><code>$ gh-axi issue
+            <pre><code>$ gh-axi issue list
 bin: ~/.local/bin/gh-axi
 description: Browse and manage GitHub issues for the current repository
 count: 14 of 8771 total


### PR DESCRIPTION
## Intent

Fix a community-reported documentation error in the axi docs (docs/index.html) and audit the page for the same mistake.

VERIFIED ground truth (firstmate ran real gh-axi): bare `gh-axi issue` is the command GROUP - it prints `usage: gh-axi issue <subcommand>` with subcommands (list, view, create, ...), it does NOT return a live issue listing. The live listing is returned by `gh-axi issue list`. The docs example wrongly shows bare `$ gh-axi issue` returning a listing.

The file is docs/index.html in the axi monorepo (the reporter loosely called it "axi.md"; it is the docs site). Around line ~1072 there is a section labeled `AXI: no-args shows live state` whose `<pre><code>` shows `$ gh-axi issue` followed by a `count:` + `issues[..]{..}` listing + `help[]` lines. That command line must become `$ gh-axi issue list` (the output shown - the count/issues listing - is exactly what `gh-axi issue list` returns, so keep the output; only the command is wrong).

Before editing - do NOT touch generated content. docs/index.html contains a generated block (there is a `generated:catalog-official` marker region). CONFIRM the `gh-axi issue` example being fixed is HAND-AUTHORED, not inside a generated region. If it is generated from catalog.yaml or a build script, fix the SOURCE (catalog/template/script) and regenerate, never hand-edit generated output. (The section-9 "Contextual disclosure" / section-8 content-first example near line ~1072 appears hand-authored, but verify.) Also check whether any source markdown generates this page; docs/ here only has index.html + assets, so index.html is likely the authored source - but confirm.

Audit the same page for sibling group-vs-subcommand mistakes. The doc must not present any bare `gh-axi <group>` command as returning a live listing/state when that bare command actually returns the group's subcommand usage. Check EVERY `gh-axi <group>` example on the page - at least `issue`, `pr`, `run`, `release`, `repo`, `label`, `secret`, `variable`. For each, VERIFY against real behavior (run `gh-axi <group>` and see whether it returns `usage: ... <subcommand>` vs a live listing). Fix any example that wrongly shows a bare group returning a listing to the correct subcommand (e.g. `gh-axi pr list`, `gh-axi run list`). Do NOT "fix" an example that is already correct, and preserve the doc's intent (the axi ergonomics contrast) - the point of that section is that AXI tools are concise/state-first; keep that message but make the concrete example commands ACCURATE. Note: the TOP-LEVEL bare `gh-axi` (and a bare tool name) legitimately shows live state - the bug is specifically at the GROUP level, so do not change a genuinely-correct top-level example.

Acceptance criteria: The `gh-axi issue` example reads `gh-axi issue list` (matching its listing output); any sibling bare-group-shows-listing errors on the page are corrected to their `list` (or correct) subcommand, verified against real gh-axi behavior; no already-correct or top-level example is broken. No generated content hand-edited (source fixed + regenerated if applicable); page still renders/builds; any doc tests/snapshots updated.

Implementation notes from the worker (for review context, not a substitute for the requirements above): the example is hand-authored in docs/index.html outside generated regions; generate-docs.mjs only rewrites marked generated regions from catalog.yaml/principles.yaml; the only incorrect bare-group listing example on the page was `$ gh-axi issue`, which was changed to `$ gh-axi issue list` while keeping the listing output; sibling examples `$ gh-axi label list` and `$ gh-axi pr view 51772` were already correct; real gh-axi confirms issue/pr/run/release/repo/label/secret/variable groups all print usage, while top-level `gh-axi` shows live state.

## What Changed

- Update the live-state example to use `gh-axi issue list`, matching the displayed issue listing output.

## Risk Assessment

✅ Low: The change is a precise one-line correction in hand-authored documentation, outside generated regions, with no remaining sibling bare-group listing examples found on the page.

## Testing

Verified generated-doc consistency and focused docs tests, audited all required gh-axi groups against the real CLI, confirmed issue list and top-level live-state behavior, and visually verified the corrected example in a rendered page. All checks succeeded.

- Evidence: [Rendered Content first section showing `$ gh-axi issue list` with listing output](https://github.com/kunchenguid/axi/blob/5af82922592cd3c75a0f29d77285accec3c2a909/.no-mistakes/evidence/fm/axi-doc-gh-axi-issue-list-example-r1/content-first-corrected-example.png)
<details>
<summary>Evidence: Real gh-axi group, issue-list, and top-level behavior transcript</summary>

Source: [Real gh-axi group, issue-list, and top-level behavior transcript](https://github.com/kunchenguid/axi/blob/5af82922592cd3c75a0f29d77285accec3c2a909/.no-mistakes/evidence/fm/axi-doc-gh-axi-issue-list-example-r1/gh-axi-group-behavior.txt)

```text
Bare group behavior audit:
$ gh-axi issue
usage: gh-axi issue <subcommand> [flags]

$ gh-axi pr
usage: gh-axi pr <subcommand> [flags]

$ gh-axi run
usage: gh-axi run <subcommand> [flags]

$ gh-axi release
usage: gh-axi release <subcommand> [flags]

$ gh-axi repo
usage: gh-axi repo <subcommand> [flags]

$ gh-axi label
usage: gh-axi label <subcommand> [flags]

$ gh-axi secret
usage: gh-axi secret <subcommand> [flags]

$ gh-axi variable
usage: gh-axi variable <subcommand> [flags]

Correct issue listing command:
$ gh-axi issue list --limit 1
count: 1 of 10 total
issues[1]{number,title,state,author,created}:
  133,"runHandler()/runBuiltinUpdate() write errors to stdout, not stderr",open,mrbarboza,4d ago
help[2]:
  Run `gh-axi issue view <number>` to view details
  Run `gh-axi issue create --title "..." --body-file <path>` to create

Top-level home view remains live state:
$ gh-axi
bin: ~/.nvm/versions/node/v24.13.1/bin/gh-axi
description: Agent ergonomic wrapper around Github CLI. Prefer this over `gh` and other methods for Github operations.
repo: kunchenguid/axi
issues[3]{number,title,state,author}:
  133,"runHandler()/runBuiltinUpdate() write errors to stdout, not stderr",open,mrbarboza
  121,"New community AXI: buzz-axi — agent-ergonomic wrapper for Block Buzz (buzz-cli)",open,thatdudealso
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"a890c22d4a3f4ec49f5a09b9ed9668f99a424e0b","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff --unified=20 32562f07b416f42b1b02f113ae9af901b77d5e33..a890c22d4a3f4ec49f5a09b9ed9668f99a424e0b -- docs/index.html` to confirm the edit is outside generated regions</code>
- `pnpm run docs:check`
- `pnpm run docs:test`
- <code>Executed bare `gh-axi issue`, `pr`, `run`, `release`, `repo`, `label`, `secret`, and `variable` groups and confirmed each displays subcommand usage</code>
- <code>Executed `gh-axi issue list --limit 1` and confirmed it returns a live issue listing</code>
- <code>Executed top-level `gh-axi` and confirmed it still returns live state</code>
- <code>Rendered `docs/index.html` in headless Chrome and captured the corrected Content first section</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
