### PR TITLE
docs: add reactive-axi to community catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ AXIs built and maintained by the community:
 | [`cyber-mux`](https://github.com/cyberuni/cyber-mux)                                               | unional            | Terminal multiplexers | Open, send, read, focus, and close terminal panes across tmux, herdr, and WezTerm through one detection-driven contract with token-efficient output.         |
 | [`oracle-axi`](https://github.com/thatdudealso/oracle-axi)                                         | thatdudealso       | Oracle Database       | Discover, create, inspect, query, export, import, maintain, and diagnose Oracle databases through safe token-efficient CLI workflows.                        |
 | [`glab-axi`](https://github.com/karotkriss/glab-axi)                                               | karotkriss         | GitLab                | Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output.  |
+| [`reactive-axi`](https://github.com/adeeshsharma/reactive-axi)                                     | adeeshsharma       | UI review             | Click any element in your live React, Vue, or Svelte dev server and resolve it to the exact source file and line before it reaches your agent.               |
 
 <!-- generated:catalog-community:end -->
 

--- a/catalog.yaml
+++ b/catalog.yaml
@@ -151,3 +151,8 @@ community:
     author: karotkriss
     domain: GitLab
     description: "Issues, merge requests, CI/CD pipelines, variables and secrets, releases, and raw API access. Wraps the official glab CLI with agent-ergonomic TOON output."
+  - name: reactive-axi
+    url: https://github.com/adeeshsharma/reactive-axi
+    author: adeeshsharma
+    domain: UI review
+    description: "Click any element in your live React, Vue, or Svelte dev server and resolve it to the exact source file and line before it reaches your agent."

--- a/docs/index.html
+++ b/docs/index.html
@@ -711,6 +711,20 @@
                     glab CLI with agent-ergonomic TOON output.
                   </td>
                 </tr>
+                <tr>
+                  <td>
+                    <a href="https://github.com/adeeshsharma/reactive-axi"
+                      ><code>reactive-axi</code></a
+                    >
+                  </td>
+                  <td>adeeshsharma</td>
+                  <td>UI review</td>
+                  <td>
+                    Click any element in your live React, Vue, or Svelte dev
+                    server and resolve it to the exact source file and line
+                    before it reaches your agent.
+                  </td>
+                </tr>
                 <!-- generated:catalog-community:end -->
               </tbody>
             </table>


### PR DESCRIPTION
## What Changed

- Added `reactive-axi` (by adeeshsharma) to `catalog.yaml` under the `community` list, with its GitHub URL, author, domain ("UI review"), and description.
- Regenerated the derived catalog tables in `README.md` and `docs/index.html` to include the new `reactive-axi` row via `pnpm run docs:gen`.

## Risk Assessment

✅ Low: Change only adds a new community catalog entry consistently across catalog.yaml, README.md, and docs/index.html, following the existing schema and generated-region format; no source or behavioral code is touched.

## Testing

This change adds a single community-catalog entry (reactive-axi) to catalog.yaml with corresponding generated rows in README.md and docs/index.html. Ran `node scripts/generate-docs.mjs --check` which confirmed the generated regions are in sync with catalog.yaml (no drift), ran the colocated generator unit tests (`node --test scripts/generate-docs.test.mjs`, 4/4 pass) covering HTML escaping and Markdown table generation used by this exact codepath, and rendered the actual docs/index.html in a headless browser via Playwright to visually confirm the new reactive-axi row displays correctly (link, author, domain, description) in the live catalog table. No functional code was touched and no findings were raised.

- Evidence: reactive-axi row rendered in docs/index.html catalog table (local file: 
<img width="1400" height="630" alt="reactive-axi-catalog" src="https://github.com/user-attachments/assets/e3ed568c-02cf-4a21-b750-6587f452b1e1" />

<details>
<summary>Evidence: docs:check drift verification (catalog.yaml -&gt; README.md/docs/index.html)</summary>

```text
$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `node scripts/generate-docs.mjs --check`
- `node --test scripts/generate-docs.test.mjs`
- `Playwright headless-browser render + screenshot of docs/index.html catalog table to visually verify the reactive-axi row`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
