### PR TITLE
ci: require no-mistakes pipeline attestation in the gate

### DIFF
--- a/.github/workflows/no-mistakes-gate-test.yml
+++ b/.github/workflows/no-mistakes-gate-test.yml
@@ -1,0 +1,43 @@
+name: no-mistakes-gate-test
+
+# The attestation gate is an inline shell script inside
+# .github/workflows/no-mistakes-required.yml, so nothing else exercises it.
+# test/no-mistakes-gate.test.mjs extracts that exact block and runs it against
+# fixtures; run it whenever the gate or its test changes.
+on:
+  push:
+    branches: [main]
+    paths:
+      - .github/workflows/no-mistakes-required.yml
+      - .github/workflows/no-mistakes-gate-test.yml
+      - test/no-mistakes-gate.test.mjs
+      - package.json
+      - pnpm-lock.yaml
+  pull_request:
+    branches: [main]
+    paths:
+      - .github/workflows/no-mistakes-required.yml
+      - .github/workflows/no-mistakes-gate-test.yml
+      - test/no-mistakes-gate.test.mjs
+      - package.json
+      - pnpm-lock.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: no-mistakes gate behaves as specified
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run test:workflows

--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -39,7 +39,7 @@ jobs:
       github.event.pull_request.user.login != 'dependabot[bot]' &&
       github.event.pull_request.user.login != 'release-please[bot]'
     steps:
-      - name: Verify no-mistakes signature in PR body
+      - name: Verify no-mistakes signature and pipeline attestation in PR body
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -49,19 +49,179 @@ jobs:
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
           if printf '%s' "${PR_BODY:-}" | grep -qF -- "$marker"; then
             echo "Found no-mistakes signature in PR #${PR_NUMBER} body."
-            exit 0
+          else
+            {
+              echo "::error::This PR was not raised through no-mistakes."
+              echo
+              echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
+              echo "That pipeline runs the required review/test/lint/CI steps and writes a"
+              echo "deterministic '## Pipeline' section into the PR body containing:"
+              echo
+              echo "    $marker"
+              echo
+              echo "See CONTRIBUTING.md for setup and the full workflow."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
           fi
-          {
-            echo "::error::This PR was not raised through no-mistakes."
-            echo
-            echo "Contributions to this repository must be submitted via 'git push no-mistakes'."
-            echo "That pipeline runs the required review/test/build/CI steps and writes a"
-            echo "deterministic '## Pipeline' section into the PR body containing:"
-            echo
-            echo "    $marker"
-            echo
-            echo "See CONTRIBUTING.md for setup and the full workflow."
-            echo
-            echo "PR author: ${PR_AUTHOR}"
-          } >&2
-          exit 1
+
+          # The signature alone only proves the pipeline wrote the body. no-mistakes
+          # >= 1.46.0 also emits a machine-readable step attestation next to it; parse
+          # that to prove review, test, and document actually ran to completion.
+          # Contract: docs/reference/pipeline-steps.md#pipeline-step-attestation in
+          # kunchenguid/no-mistakes.
+          attestation_prefix='<!-- no-mistakes-pipeline-attestation:v1 '
+          attestation_suffix=' -->'
+
+          if ! printf '%s' "${PR_BODY:-}" | grep -qF -- "$attestation_prefix"; then
+            echo "::error::This PR carries the no-mistakes signature but no pipeline attestation."
+            {
+              echo
+              echo "no-mistakes >= 1.46.0 is required (PR 670). That release writes a"
+              echo "machine-readable comment next to the signature:"
+              echo
+              echo "    ${attestation_prefix}{\"head_sha\":\"...\",\"steps\":[...]}${attestation_suffix}"
+              echo
+              echo "Upgrade no-mistakes ('no-mistakes update'), then re-run"
+              echo "'git push no-mistakes' so the PR body is rewritten with the attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Exact-substring extraction (no regex): first prefix, then the first
+          # closing token after it, mirroring how no-mistakes' own consumer test
+          # slices the payload.
+          payload="$(
+            printf '%s' "${PR_BODY:-}" | tr -d '\r' | awk -v pre="$attestation_prefix" -v suf="$attestation_suffix" '
+              found { next }
+              {
+                p = index($0, pre)
+                if (p == 0) next
+                rest = substr($0, p + length(pre))
+                s = index(rest, suf)
+                if (s == 0) next
+                print substr(rest, 1, s - 1)
+                found = 1
+              }
+            '
+          )"
+
+          if [ -z "$payload" ]; then
+            echo "::error::The no-mistakes pipeline attestation comment is malformed: no JSON payload could be extracted."
+            {
+              echo
+              echo "The '${attestation_prefix}' marker is present but is not closed by"
+              echo "'${attestation_suffix}' on the same line, or the payload is empty."
+              echo "This gate fails closed on an unreadable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          # Real JSON parsing. Emits one "<step>\t<verdict>\t<detail>" line per
+          # required step. A step recorded more than once must be completed in
+          # every record. Any skip-shaped sibling key (a future 'skipped',
+          # 'skip_reason', 'quota_...', '..._unavailable' field) with a meaningful
+          # value is rejected outright, so a skip can never ride along on a
+          # 'completed' status.
+          if ! report="$(
+            printf '%s' "$payload" | jq -r --argjson required '["review","test","document"]' '
+              if type != "object" then error("attestation payload is not a JSON object") else . end
+              | if (.steps | type) != "array" then error("attestation payload has no \"steps\" array") else . end
+              | . as $attestation
+              | $required[]
+              | . as $name
+              | [ $attestation.steps[] | select((type == "object") and ((.step? | tostring) == $name)) ] as $records
+              | if ($records | length) == 0 then
+                  "\($name)\tmissing\tno record in attestation"
+                else
+                  ([ $records[] | (.status? // null) | tostring ] | unique) as $statuses
+                  | ([ $records[]
+                       | to_entries[]
+                       | select((.key | ascii_downcase) | test("skip|quota|unavailable"))
+                       | select(.value != null and .value != false and .value != "")
+                       | .key ] | unique) as $skip_markers
+                  | if ($skip_markers | length) > 0 then
+                      "\($name)\tskip-marker\t\($skip_markers | join(","))"
+                    elif $statuses == ["completed"] then
+                      "\($name)\tok\tcompleted"
+                    else
+                      "\($name)\tbad\t\($statuses | join(","))"
+                    end
+                end
+            ' 2>&1
+          )"; then
+            echo "::error::The no-mistakes pipeline attestation payload could not be parsed as JSON."
+            {
+              echo
+              echo "jq reported:"
+              echo "$report"
+              echo
+              echo "Payload: $payload"
+              echo
+              echo "This gate fails closed on an unparseable attestation."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+
+          tab="$(printf '\t')"
+          gate_status=0
+          checked=0
+          while IFS="$tab" read -r name verdict detail; do
+            [ -n "$name" ] || continue
+            checked=$((checked + 1))
+            case "$verdict" in
+              ok)
+                echo "  ok: ${name} = completed"
+                ;;
+              missing)
+                echo "::error::The no-mistakes pipeline attestation has no '${name}' step record; '${name}' must be recorded as completed."
+                gate_status=1
+                ;;
+              skip-marker)
+                echo "::error::The no-mistakes pipeline attestation marks '${name}' with skip indicator(s) [${detail}]; quota-exhaustion and agent-unavailability skips are not accepted."
+                gate_status=1
+                ;;
+              *)
+                echo "::error::The no-mistakes pipeline attestation records '${name}' as '${detail}', not 'completed'."
+                gate_status=1
+                ;;
+            esac
+          done <<REPORT
+          $report
+          REPORT
+
+          # A verdict per required step is the only shape jq can emit for a payload
+          # it accepted. Assert it anyway so an unexpected empty report fails closed
+          # instead of reporting nothing and passing.
+          if [ "$checked" -ne 3 ]; then
+            echo "::error::The no-mistakes attestation gate reached a verdict for ${checked} of the 3 required steps (review, test, document); failing closed."
+            gate_status=1
+          fi
+
+          if [ "$gate_status" -ne 0 ]; then
+            {
+              echo
+              echo "The no-mistakes review, test, and document steps must all be recorded as"
+              echo "'completed'. A step that was skipped (pre-skipped with --skip, skipped at a"
+              echo "gate, or skipped because the agent was unavailable or out of quota), failed,"
+              echo "or never finished is not accepted."
+              echo
+              echo "Re-run 'git push no-mistakes' and let review, test, and document run."
+              echo
+              echo "Attestation payload: $payload"
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
+
+          echo "no-mistakes pipeline attestation verified for PR #${PR_NUMBER}: review, test, and document all completed."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,8 @@ Because the release PR carries the version bump, a downstream `*-axi` tool only 
 - The AXI catalog and principle summaries are single-sourced from `catalog.yaml` and `principles.yaml`.
   `pnpm run docs:gen` rewrites the marked `generated:...` regions of README.md and docs/index.html; never hand-edit those regions.
   The `docs-check` workflow runs `pnpm run docs:check` and fails on drift, including when `.agents/skills/axi/SKILL.md` section headings stop matching the canonical principle titles.
+- The no-mistakes PR gate in `.github/workflows/no-mistakes-required.yml` is one self-contained inline `run:` script mirrored across sibling repos from `kunchenguid/gh-axi`; port that script byte-for-byte and keep this repo's own `on:`/`paths-ignore`/`if:` exemptions.
+  `pnpm run test:workflows` extracts that exact block and executes it against fixtures (`test/no-mistakes-gate.test.mjs`, node:test), and the `no-mistakes-gate-test` workflow runs it in CI.
 
 ## Maintaining this file
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,7 @@ export default defineConfig(
     files: [
       "packages/axi-sdk-js/**/*.{js,cjs,mjs,ts,cts,mts}",
       "scripts/**/*.mjs",
+      "test/**/*.mjs",
     ],
     languageOptions: {
       globals: {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "docs:gen": "node scripts/generate-docs.mjs",
     "docs:check": "node scripts/generate-docs.mjs --check",
     "docs:test": "node --test scripts/generate-docs.test.mjs",
-    "lint": "eslint packages/axi-sdk-js/src packages/axi-sdk-js/test eslint.config.mjs scripts",
+    "test:workflows": "node --test test/no-mistakes-gate.test.mjs",
+    "lint": "eslint packages/axi-sdk-js/src packages/axi-sdk-js/test eslint.config.mjs scripts test",
     "format": "prettier --write \"packages/axi-sdk-js/**/*.{ts,js,mjs,cjs,json,md}\" \".github/workflows/axi-sdk-js-*.yml\" \"release-please-config.json\" \".release-please-manifest.json\"",
     "format:check": "prettier --check \"packages/axi-sdk-js/**/*.{ts,js,mjs,cjs,json,md}\" \".github/workflows/axi-sdk-js-*.yml\" \"release-please-config.json\" \".release-please-manifest.json\""
   },

--- a/packages/axi-sdk-js/test/release-ci-exclusions.test.ts
+++ b/packages/axi-sdk-js/test/release-ci-exclusions.test.ts
@@ -252,6 +252,7 @@ describe("release-please CI exclusions", () => {
       "axi-sdk-js-ci.yml",
       "docs-check.yml",
       "guard-generated-files.yml",
+      "no-mistakes-gate-test.yml",
       "no-mistakes-required.yml",
     ]);
 

--- a/test/no-mistakes-gate.test.mjs
+++ b/test/no-mistakes-gate.test.mjs
@@ -1,0 +1,206 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parse } from "yaml";
+
+const root = fileURLToPath(new URL("..", import.meta.url));
+const workflowPath = join(
+  root,
+  ".github",
+  "workflows",
+  "no-mistakes-required.yml",
+);
+
+/**
+ * The gate lives as an inline `run:` block so the whole file can be mirrored
+ * into sibling repositories as one unit. Extract that exact block and execute
+ * it, so these tests exercise what CI runs rather than a copy of it.
+ */
+function extractGateScript() {
+  const doc = parse(readFileSync(workflowPath, "utf8"));
+  const script = doc.jobs.check.steps[0]?.run;
+  if (!script) throw new Error("no-mistakes gate step has no run block");
+  return script;
+}
+
+const scriptPath = join(mkdtempSync(join(tmpdir(), "nm-gate-")), "gate.sh");
+writeFileSync(scriptPath, extractGateScript());
+
+function hasCommand(command) {
+  return spawnSync("sh", ["-c", `command -v ${command}`]).status === 0;
+}
+
+// The gate is a bash script that parses JSON with jq, exactly as the
+// ubuntu-latest runner does. Never skip on CI: a silently skipped gate test is
+// worse than no test. Locally, skip when jq is absent rather than failing a
+// contributor's test run over an unrelated missing tool.
+const runnable = hasCommand("bash") && hasCommand("jq");
+if (process.env.CI && !runnable) {
+  throw new Error(
+    "CI must provide bash and jq to exercise the no-mistakes gate",
+  );
+}
+
+function runGate(body) {
+  const result = spawnSync("bash", [scriptPath], {
+    env: {
+      ...process.env,
+      PR_BODY: body,
+      PR_AUTHOR: "somedev",
+      PR_NUMBER: "42",
+    },
+    encoding: "utf8",
+  });
+  return {
+    code: result.status ?? -1,
+    output: `${result.stdout}${result.stderr}`,
+  };
+}
+
+const SIGNATURE =
+  "Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)";
+const ATTESTATION_PREFIX = "<!-- no-mistakes-pipeline-attestation:v1 ";
+const ATTESTATION_SUFFIX = " -->";
+const HEAD_SHA = "12df13109c6ad8d64646b85ac7170b23afe6e9bf";
+
+/** A PR body shaped like the one no-mistakes writes. */
+function prBody(attestationPayload) {
+  const attestation =
+    attestationPayload === undefined
+      ? ""
+      : `${ATTESTATION_PREFIX}${attestationPayload}${ATTESTATION_SUFFIX}\n\n`;
+  return [
+    "## What Changed\n\n- something\n",
+    `## Pipeline\n\n${SIGNATURE}\n\n${attestation}`,
+    "<details>\n<summary>Review</summary>\n\nok\n\n</details>\n",
+  ].join("\n");
+}
+
+function attestation(steps) {
+  return JSON.stringify({
+    head_sha: HEAD_SHA,
+    steps: steps.map(([step, status]) => ({ step, status })),
+  });
+}
+
+/** The step snapshot a healthy run produces when the PR body is written. */
+const HEALTHY_STEPS = [
+  ["intent", "completed"],
+  ["rebase", "completed"],
+  ["review", "completed"],
+  ["test", "completed"],
+  ["document", "completed"],
+  ["lint", "completed"],
+  ["push", "completed"],
+  ["pr", "running"],
+  ["ci", "pending"],
+];
+
+function withStatus(step, status) {
+  return HEALTHY_STEPS.map(([name, current]) =>
+    name === step ? [name, status] : [name, current],
+  );
+}
+
+describe("no-mistakes PR gate", { skip: !runnable }, () => {
+  it("accepts a body whose attestation completes review, test, and document", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)));
+    assert.equal(code, 0);
+    assert.match(output, /review, test, and document all completed/);
+  });
+
+  it("still rejects a body with no no-mistakes signature", () => {
+    const { code, output } = runGate("## Intent\n\nhand-written body\n");
+    assert.equal(code, 1);
+    assert.match(output, /was not raised through no-mistakes/);
+    assert.match(output, /git push no-mistakes/);
+  });
+
+  it("rejects a signed body with no attestation and names the required version", () => {
+    const { code, output } = runGate(prBody());
+    assert.equal(code, 1);
+    assert.match(output, /no pipeline attestation/);
+    assert.ok(output.includes("no-mistakes >= 1.46.0 is required (PR 670)"));
+  });
+
+  // Every skip route no-mistakes has - `--skip`, a user skip at a gate, an
+  // automatic pipeline skip, or a run that ran out of agent quota - lands on
+  // the raw `skipped` status, and an unavailable agent surfaces as `failed`.
+  for (const status of ["skipped", "failed", "running", "pending"]) {
+    it(`rejects an attestation whose test step is ${status}`, () => {
+      const { code, output } = runGate(
+        prBody(attestation(withStatus("test", status))),
+      );
+      assert.equal(code, 1);
+      assert.ok(output.includes(`records 'test' as '${status}'`));
+    });
+  }
+
+  it("rejects an attestation that omits a required step entirely", () => {
+    const steps = HEALTHY_STEPS.filter(([name]) => name !== "document");
+    const { code, output } = runGate(prBody(attestation(steps)));
+    assert.equal(code, 1);
+    assert.ok(output.includes("no 'document' step record"));
+  });
+
+  it("rejects a required step recorded twice unless every record completed", () => {
+    const steps = [...HEALTHY_STEPS, ["review", "skipped"]];
+    const { code, output } = runGate(prBody(attestation(steps)));
+    assert.equal(code, 1);
+    assert.ok(output.includes("records 'review' as 'completed,skipped'"));
+  });
+
+  // v1 carries no skip sibling field, so `status` is the only skip channel
+  // today. Fail closed if a later schema ever hangs a skip reason off an
+  // otherwise-completed step instead of widening the gate silently.
+  for (const marker of [
+    { skip_reason: "quota exhausted" },
+    { skipped: true },
+    { agent_unavailable: true },
+    { quota_exhausted: true },
+  ]) {
+    const key = Object.keys(marker)[0];
+    it(`rejects a completed step carrying a ${key} marker`, () => {
+      const payload = JSON.stringify({
+        head_sha: HEAD_SHA,
+        steps: HEALTHY_STEPS.map(([step, status]) =>
+          step === "review" ? { step, status, ...marker } : { step, status },
+        ),
+      });
+      const { code, output } = runGate(prBody(payload));
+      assert.equal(code, 1);
+      assert.ok(output.includes(`skip indicator(s) [${key}]`));
+    });
+  }
+
+  it("fails closed on an attestation payload that is not valid JSON", () => {
+    const { code, output } = runGate(
+      prBody('{"head_sha":"abc","steps":[{"step":"review",'),
+    );
+    assert.equal(code, 1);
+    assert.match(output, /could not be parsed as JSON/);
+  });
+
+  it("fails closed when the payload has no steps array", () => {
+    const { code, output } = runGate(prBody('{"head_sha":"abc"}'));
+    assert.equal(code, 1);
+    assert.match(output, /could not be parsed as JSON/);
+  });
+
+  it("fails closed when the attestation comment is never closed", () => {
+    const body = `## Pipeline\n\n${SIGNATURE}\n\n${ATTESTATION_PREFIX}{"head_sha":"abc","steps":[]}\n`;
+    const { code, output } = runGate(body);
+    assert.equal(code, 1);
+    assert.match(output, /no JSON payload could be extracted/);
+  });
+
+  it("accepts a CRLF body", () => {
+    const body = prBody(attestation(HEALTHY_STEPS)).replace(/\n/g, "\r\n");
+    const { code } = runGate(body);
+    assert.equal(code, 0);
+  });
+});


### PR DESCRIPTION
## What changed

Mirrors the attestation gate that landed on `gh-axi` main (kunchenguid/gh-axi#111) into this repo's `.github/workflows/no-mistakes-required.yml`.

The gate step's inline `run:` script is now **byte-for-byte identical** to gh-axi's (verified by parsing both workflows and comparing `jobs.check.steps[0].run`: 6583 chars, identical). It now:

- keeps the existing "signature missing" failure path;
- requires the `<!-- no-mistakes-pipeline-attestation:v1 {...} -->` comment, and fails with `no-mistakes >= 1.46.0 is required (PR 670)` when the signature is present but the attestation is missing;
- extracts the payload by exact substring (no regex) and fails closed if the comment is never closed;
- jq-parses `steps[]` and requires `review`, `test`, and `document` to all be `status == "completed"` (every record, if a step appears twice);
- rejects any skip-shaped sibling key (`skip*`, `quota*`, `*unavailable`) on a required step, so a skip can never ride along on a `completed` status;
- fails closed on malformed/unparseable JSON, and asserts a verdict was reached for all 3 required steps.

**This repo's own triggers and exemptions are untouched.** `on:` (types/branches/`paths-ignore` including the `packages/axi-sdk-js/**` release-please paths), `concurrency`, `permissions`, the author exemption `if:`, and the job name `PR must be raised via no-mistakes` are all exactly as before. Only the step name and the script body changed.

## Test

New `test/no-mistakes-gate.test.mjs` (node:test, matching this repo's root `node --test` convention) parses the workflow YAML, extracts that exact inline block, writes it to a temp file, and executes it with `bash` against fixture PR bodies - so it exercises what CI runs, not a copy.

Wired up as `pnpm run test:workflows` and run in CI by the new `no-mistakes-gate-test` workflow (path-filtered to the gate, its test, and lockfile/manifest). The test throws on CI if `bash`/`jq` are unavailable, so it can never silently skip there.

<details>
<summary><code>pnpm run test:workflows</code> - 17/17 pass</summary>

```
$ node --test test/no-mistakes-gate.test.mjs
▶ no-mistakes PR gate
  ✔ accepts a body whose attestation completes review, test, and document (127.533375ms)
  ✔ still rejects a body with no no-mistakes signature (20.305834ms)
  ✔ rejects a signed body with no attestation and names the required version (71.213958ms)
  ✔ rejects an attestation whose test step is skipped (144.828792ms)
  ✔ rejects an attestation whose test step is failed (90.678ms)
  ✔ rejects an attestation whose test step is running (97.759792ms)
  ✔ rejects an attestation whose test step is pending (95.561083ms)
  ✔ rejects an attestation that omits a required step entirely (73.789ms)
  ✔ rejects a required step recorded twice unless every record completed (97.998167ms)
  ✔ rejects a completed step carrying a skip_reason marker (99.103375ms)
  ✔ rejects a completed step carrying a skipped marker (245.205667ms)
  ✔ rejects a completed step carrying a agent_unavailable marker (104.858209ms)
  ✔ rejects a completed step carrying a quota_exhausted marker (84.584ms)
  ✔ fails closed on an attestation payload that is not valid JSON (54.725125ms)
  ✔ fails closed when the payload has no steps array (90.003375ms)
  ✔ fails closed when the attestation comment is never closed (141.863792ms)
  ✔ accepts a CRLF body (75.507375ms)
✔ no-mistakes PR gate (1718.605292ms)
ℹ tests 17
ℹ suites 1
ℹ pass 17
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 1995.201
```

</details>

`packages/axi-sdk-js/test/release-ci-exclusions.test.ts` asserts the exact inventory of workflows that carry a `pull_request` trigger, so the new workflow is registered there. Its path filter selects nothing in the release-output set (root `package.json` is not `packages/axi-sdk-js/package.json`), so a release-please PR still creates no run for it.

## Notes

The advisory `PR must be raised via no-mistakes` check will fail on this PR: it is a direct PR with no pipeline signature. That is expected and non-blocking for internal CI tooling. The real checks (gate test, lint/format, docs, build/test, guard) must be green.
