### PR TITLE
ci: bind the no-mistakes attestation to the current PR head

### DIFF
--- a/.github/workflows/no-mistakes-required.yml
+++ b/.github/workflows/no-mistakes-required.yml
@@ -44,6 +44,7 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -eu
           marker='Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)'
@@ -170,7 +171,31 @@ jobs:
             exit 1
           fi
 
-          echo "Attestation head_sha: $(printf '%s' "$payload" | jq -r '.head_sha // "(absent)"')"
+          attested_head="$(printf '%s' "$payload" | jq -r '.head_sha // ""')"
+          echo "Attestation head_sha: ${attested_head:-(absent)}"
+
+          # Head binding. The attestation describes the commit no-mistakes ran
+          # its steps on; a later push moves the PR head without rewriting the
+          # body, so an attestation that does not name the current head proves
+          # nothing about the code being merged. A `synchronize` whose body was
+          # NOT rewritten by no-mistakes going red is the intended contract, not
+          # a false positive.
+          if [ -z "$attested_head" ] || [ -z "${PR_HEAD_SHA:-}" ] || [ "$attested_head" != "$PR_HEAD_SHA" ]; then
+            echo "::error::The no-mistakes pipeline attestation is STALE for the current head of PR #${PR_NUMBER}."
+            {
+              echo
+              echo "Attestation head_sha: ${attested_head:-(absent)}"
+              echo "PR head sha:          ${PR_HEAD_SHA:-(absent)}"
+              echo
+              echo "A commit was pushed after the no-mistakes run, so the attestation does not"
+              echo "describe the code this PR now proposes to merge."
+              echo
+              echo "Re-run 'git push no-mistakes' to refresh it."
+              echo
+              echo "PR author: ${PR_AUTHOR}"
+            } >&2
+            exit 1
+          fi
 
           tab="$(printf '\t')"
           gate_status=0

--- a/test/no-mistakes-gate.test.mjs
+++ b/test/no-mistakes-gate.test.mjs
@@ -45,13 +45,14 @@ if (process.env.CI && !runnable) {
   );
 }
 
-function runGate(body) {
+function runGate(body, headSha = HEAD_SHA) {
   const result = spawnSync("bash", [scriptPath], {
     env: {
       ...process.env,
       PR_BODY: body,
       PR_AUTHOR: "somedev",
       PR_NUMBER: "42",
+      PR_HEAD_SHA: headSha,
     },
     encoding: "utf8",
   });
@@ -80,9 +81,9 @@ function prBody(attestationPayload) {
   ].join("\n");
 }
 
-function attestation(steps) {
+function attestation(steps, headSha = HEAD_SHA) {
   return JSON.stringify({
-    head_sha: HEAD_SHA,
+    head_sha: headSha,
     steps: steps.map(([step, status]) => ({ step, status })),
   });
 }
@@ -176,6 +177,48 @@ describe("no-mistakes PR gate", { skip: !runnable }, () => {
       assert.ok(output.includes(`skip indicator(s) [${key}]`));
     });
   }
+
+  // Head binding: the attestation describes the commit no-mistakes ran on, so
+  // an attestation naming any other commit says nothing about what is being
+  // merged. A synchronize whose body was not rewritten by no-mistakes going red
+  // is the contract, not a false positive.
+  it("accepts an attestation whose head_sha is the PR's current head", () => {
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, HEAD_SHA)),
+      HEAD_SHA,
+    );
+    assert.equal(code, 0);
+    assert.match(output, new RegExp(`Attestation head_sha: ${HEAD_SHA}`));
+  });
+
+  it("rejects an attestation whose head_sha is not the PR's current head", () => {
+    const staleSha = "0000000000000000000000000000000000000000";
+    const { code, output } = runGate(
+      prBody(attestation(HEALTHY_STEPS, staleSha)),
+      HEAD_SHA,
+    );
+    assert.equal(code, 1);
+    assert.match(output, /attestation is STALE for the current head/);
+    assert.match(output, /Re-run 'git push no-mistakes' to refresh it/);
+    assert.ok(output.includes(staleSha) && output.includes(HEAD_SHA));
+  });
+
+  it("fails closed when the attestation carries no head_sha at all", () => {
+    const payload = JSON.stringify({
+      steps: HEALTHY_STEPS.map(([step, status]) => ({ step, status })),
+    });
+    const { code, output } = runGate(prBody(payload), HEAD_SHA);
+    assert.equal(code, 1);
+    assert.match(output, /attestation is STALE for the current head/);
+    assert.match(output, /Attestation head_sha: \(absent\)/);
+  });
+
+  it("fails closed when the PR head sha is unavailable", () => {
+    const { code, output } = runGate(prBody(attestation(HEALTHY_STEPS)), "");
+    assert.equal(code, 1);
+    assert.match(output, /attestation is STALE for the current head/);
+    assert.match(output, /PR head sha: +\(absent\)/);
+  });
 
   it("fails closed on an attestation payload that is not valid JSON", () => {
     const { code, output } = runGate(


### PR DESCRIPTION
## What Changed

The attestation gate parsed the `no-mistakes-pipeline-attestation:v1` payload's
`head_sha` and printed it, but never compared it to the PR's current head. A
commit pushed directly after a no-mistakes run therefore passed the gate on a
stale attestation that described different code.

This ports the head binding that landed on `lavish-axi` main (PR #271):

- `PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}` added to the gate
  step's `env:`.
- After parsing the payload, the gate fails unless the attestation's `head_sha`
  is present, the PR head sha is present, and the two are equal. On mismatch it
  emits an `::error::` naming both shas and telling the author to re-run
  `git push no-mistakes`.
- Fails closed on an absent `head_sha` and on an absent `PR_HEAD_SHA`.

A `synchronize` event whose PR body was not rewritten by no-mistakes now goes
red. That is the attestation contract, not a false positive.

This repo's `paths-ignore`, author exemptions, `if:` condition, and job name are
unchanged. The gate `run:` script is byte-identical to `lavish-axi` main's.

## Tests

Four regression cases added to `test/no-mistakes-gate.test.mjs`, mirroring
lavish's and adapted to this repo's `describe`/`it` + YAML-parse extraction:
matching head passes, stale head fails, missing `head_sha` fails closed, missing
`PR_HEAD_SHA` fails closed.

<details>
<summary>pnpm run test:workflows</summary>

```
$ node --test test/no-mistakes-gate.test.mjs
▶ no-mistakes PR gate
  ✔ accepts a body whose attestation completes review, test, and document
  ✔ still rejects a body with no no-mistakes signature
  ✔ rejects a signed body with no attestation and names the required version
  ✔ rejects an attestation whose test step is skipped
  ✔ rejects an attestation whose test step is failed
  ✔ rejects an attestation whose test step is running
  ✔ rejects an attestation whose test step is pending
  ✔ rejects an attestation that omits a required step entirely
  ✔ rejects a required step recorded twice unless every record completed
  ✔ rejects a completed step carrying a skip_reason marker
  ✔ rejects a completed step carrying a skipped marker
  ✔ rejects a completed step carrying a agent_unavailable marker
  ✔ rejects a completed step carrying a quota_exhausted marker
  ✔ accepts an attestation whose head_sha is the PR's current head
  ✔ rejects an attestation whose head_sha is not the PR's current head
  ✔ fails closed when the attestation carries no head_sha at all
  ✔ fails closed when the PR head sha is unavailable
  ✔ fails closed on an attestation payload that is not valid JSON
  ✔ fails closed when the payload has no steps array
  ✔ fails closed when the attestation comment is never closed
  ✔ accepts a CRLF body
✔ no-mistakes PR gate (361.099541ms)
ℹ tests 21
ℹ suites 1
ℹ pass 21
ℹ fail 0
ℹ skipped 0
```

</details>

<details>
<summary>lint / format:check / docs:check</summary>

```
$ eslint packages/axi-sdk-js/src packages/axi-sdk-js/test eslint.config.mjs scripts test
(clean)

$ prettier --check ...
Checking formatting...
All matched files use Prettier code style!

$ node scripts/generate-docs.mjs --check
docs:check ok — generated regions match their sources
```

</details>

## Note

This PR was raised directly, not through `git push no-mistakes`, so the advisory
`Require no-mistakes` check will fail on it by design. The real checks (build,
test, guard-generated-files) are the ones to read.
