### PR TITLE
docs: broaden /axi skill trigger to any CLI tool

### DIFF
--- a/.agents/skills/axi/SKILL.md
+++ b/.agents/skills/axi/SKILL.md
@@ -2,7 +2,7 @@
 name: axi
 description: >
   Agent eXperience Interface (AXI) — ergonomic standards for building CLI tools that agents
-  use via shell execution. Use when building, modifying, or reviewing any agent-facing CLI.
+  use via shell execution. Use when building, modifying, or reviewing any CLI tool.
 ---
 
 # Agent eXperience Interface (AXI)


### PR DESCRIPTION
## Summary

Broadens the trigger of the in-repo AXI skill (`.agents/skills/axi/SKILL.md`) so it fires for any CLI tool, not only an "agent-facing" one.
The old wording made agents skip the skill whenever they were working on an ordinary CLI, which is exactly the moment the AXI principles should apply.
This is the first half of Linear ticket [DEV-49](https://linear.app/hyfin/issue/DEV-49); the decision that this in-repo skill IS the `/axi` skill (single source, no wrapper) comes from ticket `010-axi-skill-shape.md`.

## Acceptance criteria

- [x] The frontmatter `description` of `.agents/skills/axi/SKILL.md` no longer contains "agent-facing" and reads naturally as any CLI tool.
- [x] The skill body is unchanged; only the frontmatter description line differs.
- [x] The PR targets our fork `yjuyjuy/axi`, never upstream `kunchenguid/axi`.

## Approach

One line changed:

- before: `Use when building, modifying, or reviewing any agent-facing CLI.`
- after: `Use when building, modifying, or reviewing any CLI tool.`

I searched the whole repo for other copies of that trigger sentence and for the string "agent-facing".
There is no duplicate trigger sentence: `README.md`, `docs/index.html`, `principles.yaml`, and `catalog.yaml` do not restate it.
The only other occurrence of "agent-facing" is in `catalog.yaml` line 284, inside an admission-review comment describing a specific catalog entry's contract file; it is unrelated to the skill trigger, so it was deliberately left alone.
No tiering or compliance-bar language was added: all 10 principles remain mandatory everywhere, and the compliance bar is tracked separately in DEV-52.

## Tradeoffs

An alternative phrasing was "any command-line tool", but "any CLI tool" keeps the sentence close to the original and matches the vocabulary used in the rest of the skill.
Widening the trigger means the skill will load in more sessions, which is the intent; the cost is a slightly broader match, which is the correct trade because AXI's principles are meant to apply to CLIs generally.
Risk is minimal: the change is documentation-only, and it cannot affect any package build or published artifact.

## Test evidence

- `pnpm run docs:check` -> `docs:check ok — generated regions match their sources` (exit 0). This is the repo gate that fails on drift between `catalog.yaml`/`principles.yaml` and the generated regions of `README.md`/`docs/index.html`, and it also checks that the skill's section headings still match the canonical principle titles.
- Repo-wide grep confirms zero remaining occurrences of "agent-facing" in the skill and no duplicate trigger sentence elsewhere.

Coverage declaration: this change was not built test-first and has no end-to-end coverage.
The reason is that the change is a single documentation sentence in skill frontmatter; there is no executable behavior to assert, and the repo has no test that pins skill description prose.
The existing `docs:check` gate is the closest available automated verification and it passes.

## Verification checklist

- [x] Every section above is filled in substantively from the actual change
- [x] All links are full clickable URLs
- [x] The description was re-read once before opening the PR

## Related tickets

- [DEV-49](https://linear.app/hyfin/issue/DEV-49) - this PR is the first half; the fleet skills manifest and its bootstrap integration land separately in the firstmate repo.
- [DEV-52](https://linear.app/hyfin/issue/DEV-52) - the compliance bar, deliberately out of scope here.
